### PR TITLE
go mod tidy/vendor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	k8s.io/apimachinery v0.21.0
 	k8s.io/client-go v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -388,4 +388,5 @@ sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 # sigs.k8s.io/structured-merge-diff/v4 v4.1.0
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml


### PR DESCRIPTION
sigs.k8s.io/yaml was not required in go.mod and vendor/modules.txt
