### PR TITLE
Add addons/finalizers resource permission

### DIFF
--- a/config/deploy/rbac.yaml
+++ b/config/deploy/rbac.yaml
@@ -46,6 +46,7 @@ rules:
   resources:
   - addons
   - addons/status
+  - addons/finalizers
   verbs:
   - get
   - list


### PR DESCRIPTION
Adds `addons/finalizers` permission for the addon-operator. This permission only exists in OpenShift and without it our e2e tests on OCP fail:

```
controller-runtime.manager.controller.addon	Reconciler error	{"reconciler group": "addons.managed.openshift.io", "reconciler kind": "Addon", "name": "addon-c01m94lbi", "namespace": "", "error": "failed to ensure wanted namespaces: namespaces \"namespace-oibabdsoi\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}
```

Signed-off-by: Nico Schieder <nschieder@redhat.com>