### PR TITLE
fix excludes and goimports  in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
-exclude: "vendor/ | *.deepcopy.go"
+exclude: |
+  (?x)(
+    (^vendor/)|
+    (.deepcopy.go$)
+  )
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.4.0
@@ -24,7 +28,7 @@ repos:
   hooks:
   - id: goimports
     name: goimports
-    entry: .cache/dependencies/bin/goimports -local github.com/openshift/addon-operator -w
+    entry: hack/ensure-and-run-goimports.sh
     language: system
     types: [go]
 

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ $(YQ):
 		&& echo
 
 # setup goimports
+goimports: $(GOIMPORTS)
 GOIMPORTS:=$(DEPENDENCIES)/goimports/$(GOIMPORTS_VERSION)
 $(GOIMPORTS):
 	@echo "installing goimports $(GOIMPORTS_VERSION)..."

--- a/hack/ensure-and-run-goimports.sh
+++ b/hack/ensure-and-run-goimports.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+# this script ensures that the `goimports` dependency is present
+# and then executes goimport passing all arguments forward
+
+make -s goimports
+.cache/dependencies/bin/goimports -local github.com/openshift/addon-operator -w -l "$@"


### PR DESCRIPTION
Fixed:
- `excludes` regex to properly exclude vendor folder
- `goimports` call to ensure that the goimports dependency is available before it gets called

Tested by moving an import in cmd/addon-operator-manager/main.go to another group  and then running pre-commit with `pre-commit run -a` to run it on everything in the repo, thus ensuring that old stuff doesn't break.

Without the fixed `exclude` regex (this is a regex - not a glob!)  the test would have also rewritten some things in `vendor/...`.

I rewrote the `exclude` regex as a "verbose regex" to make it easier to parse from a human perspective. This point is up for debate!

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>