### PR TITLE
Refactor Makefile, add make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,11 +285,11 @@ build-image-addon-operator-bundle: clean-image-cache-addon-operator-bundle confi
 
 # Warning!
 # The bundle image needs to be pushed so the opm CLI can create the index image.
-build-image-addon-operator-index: $(OPM) clean-image-cache-addon-operator-index | build-image-addon-operator-bundle push-image-addon-operator-bundle ## Index image contains a list of bundle images for use in a CatalogSource.
+build-image-addon-operator-index: opm clean-image-cache-addon-operator-index | build-image-addon-operator-bundle push-image-addon-operator-bundle ## Index image contains a list of bundle images for use in a CatalogSource.
 	$(eval IMAGE_NAME := addon-operator-index)
 	@echo "building image ${IMAGE_ORG}/${IMAGE_NAME}:${VERSION}..."
 	@(source hack/determine-container-runtime.sh; \
-		opm index add --container-tool $$CONTAINER_COMMAND \
+		$(OPM) index add --container-tool $$CONTAINER_COMMAND \
 		--bundles ${IMAGE_ORG}/addon-operator-bundle:${VERSION} \
 		--tag ${IMAGE_ORG}/${IMAGE_NAME}:${VERSION}; \
 		$$CONTAINER_COMMAND image save -o ".cache/image/${IMAGE_NAME}.tar" "${IMAGE_ORG}/${IMAGE_NAME}:${VERSION}"; \


### PR DESCRIPTION
Small PR just to get my hands dirty. I'm adding this `make help` helper copied from kubebuilder. Also I refactored the way we download go binaries (again from kubebuilder). 

I took the liberty to simply output binaries to `.cache/dependencies/bin`. If binaries versions change the workflow is probably to `make clean + make all-deps`, so I feel we can simplify the structure and ignore versions in paths.

A feedback I have is I found the Makefile very hard to read, I feel it beats the purpose of helping developer workflow. I had not seen `.SECONDEXPANSION` before :cold_sweat: not sure what it does yet...lol

```
Usage:
  make <target>

General
  help             Display this help.

Compile
  all              compile operator for amd64 arch
  version          print version
  clean            rm -fr bin .cache

Dependencies
  kind             Download kind locally if necessary.
  controller-gen   Download controller-gen locally if necessary.
  goimports        Download goimports locally if necessary.
  yq               Download yq locally if necessary.
  golangci-lint    Download golangci-lint locally if necessary.
  opm              Download operator-framework/operator-registry binary.
  all-deps         Downloads all project deps.

Deployment
  run              Run against the configured Kubernetes cluster in ~/.kube/config or $KUBECONFIG

Generators
  generate         Generate code and manifests e.g. CRD, RBAC etc.
  sandwich         Makes sandwich - https://xkcd.com/149/

Testing and Linting
  lint             Runs code-generators, checks for clean directory and lints the source code.
  test-unit        Runs unittests
  test-e2e         Runs the E2E testsuite against the currently selected cluster.
  test-e2e-local   Sets up a local kind cluster and runs E2E tests against this local cluster.
  test-e2e-ci      Run the E2E testsuite after installing the AddonOperator into the cluster.
  setup-e2e-kind   make sure that we install our components into the kind cluster and disregard normal $KUBECONFIG
  create-kind-cluster  create kind cluster
  delete-kind-cluster  delete kind cluster
  apply-olm        Installs OLM (Operator Lifecycle Manager) into the currently selected cluster.
  apply-openshift-console  Installs the OpenShift/OKD console into the currently selected cluster.
  load-ao          Load Addon Operator Image into kind
  apply-ao         Installs the Addon Operator into the kind e2e cluster.

OLM
  build-image-addon-operator-bundle  Bundle image contains the manifests and CSV for a single version of this operator.
  build-image-addon-operator-index  Index image contains a list of bundle images for use in a CatalogSource.

Container Images
  build-images     build all images
  push-images      push all images
```