### PR TITLE
explicit run-addon-operator-manager target to show it in `make help` …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ help:
 		if (helpMessage) { \
 			helpCommand = substr($$1, 0, index($$1, ":")-1); \
 			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
-			printf "  ${GREEN}%-22s${RESET}%s\n", helpCommand, helpMessage; \
+			printf "  ${GREEN}%-30s${RESET}%s\n", helpCommand, helpMessage; \
 		} \
 	} \
 	/^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } \
@@ -229,6 +229,9 @@ dependencies: \
 	$(GOIMPORTS) \
 	$(GOLANGCI_LINT)
 .PHONY: dependencies
+
+## run addon operator manager built from current codebase
+run-addon-operator-manager: run-addon-operator-manager
 
 ## Run cmd/% against $KUBECONFIG.
 run-%: generate

--- a/Makefile
+++ b/Makefile
@@ -230,8 +230,9 @@ dependencies: \
 	$(GOLANGCI_LINT)
 .PHONY: dependencies
 
-## run addon operator manager built from current codebase
-run-addon-operator-manager: run-addon-operator-manager
+## Run cmd/addon-operator-manager against $KUBECONFIG.
+run-addon-operator-manager:
+.PHONY: run-addon-operator-manager
 
 ## Run cmd/% against $KUBECONFIG.
 run-%: generate


### PR DESCRIPTION
…and to autocomplete

![image](https://user-images.githubusercontent.com/5539202/124138027-8b271800-da86-11eb-84cd-2136548cf0d6.png)

https://user-images.githubusercontent.com/5539202/124138472-f7a21700-da86-11eb-99de-cedcfc19ad80.mp4

What do you think?


Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>