### PR TITLE
Don't update child namespaces

### DIFF
--- a/internal/controllers/phase_ensure_wanted_namespaces.go
+++ b/internal/controllers/phase_ensure_wanted_namespaces.go
@@ -97,7 +97,10 @@ func (r *AddonReconciler) ensureNamespace(ctx context.Context, addon *addonsv1al
 
 // reconciles a Namespace and returns the current object as observed.
 // prevents adoption of Namespaces (unowned or owned by something else)
+// reconciling a Namespace means: creating it when it is not present
+// and erroring if our controller is not the owner of said Namespace
 func reconcileNamespace(ctx context.Context, c client.Client, namespace *corev1.Namespace) (*corev1.Namespace, error) {
+
 	currentNamespace := &corev1.Namespace{}
 
 	{
@@ -117,14 +120,7 @@ func reconcileNamespace(ctx context.Context, c client.Client, namespace *corev1.
 		return nil, errNotOwnedByUs
 	}
 
-	{
-		ensuredNamespace := namespace.DeepCopy()
-		err := c.Update(ctx, ensuredNamespace)
-		if err != nil {
-			return nil, err
-		}
-		return ensuredNamespace, nil
-	}
+	return currentNamespace, nil
 }
 
 // Tests if the controller reference on `wanted` matches the one on `current`

--- a/internal/controllers/phase_ensure_wanted_namespaces_test.go
+++ b/internal/controllers/phase_ensure_wanted_namespaces_test.go
@@ -238,26 +238,6 @@ func TestReconcileNamespace_CreateWithCollisionWithOtherOwner(t *testing.T) {
 	}, testutil.IsCoreV1NamespacePtr)
 }
 
-func TestReconcileNamespace_Update(t *testing.T) {
-	c := testutil.NewClient()
-	c.On("Get", testutil.IsContext, testutil.IsObjectKey, testutil.IsCoreV1NamespacePtr).Run(func(args mock.Arguments) {
-		arg := args.Get(2).(*corev1.Namespace)
-		newTestNamespace().DeepCopyInto(arg)
-	}).Return(nil)
-	c.On("Update", testutil.IsContext, testutil.IsCoreV1NamespacePtr, mock.Anything).Return(nil)
-
-	ctx := context.Background()
-	reconciledNamespace, err := reconcileNamespace(ctx, c, newTestNamespace())
-	require.NoError(t, err)
-	assert.NotNil(t, reconciledNamespace)
-	assert.Equal(t, newTestNamespace(), reconciledNamespace)
-	c.AssertExpectations(t)
-	c.AssertCalled(t, "Get", testutil.IsContext, client.ObjectKey{
-		Name: "namespace-1",
-	}, testutil.IsCoreV1NamespacePtr)
-	c.AssertCalled(t, "Update", testutil.IsContext, testutil.IsCoreV1NamespacePtr, mock.Anything)
-}
-
 func TestReconcileNamespace_CreateWithClientError(t *testing.T) {
 	timeoutErr := k8sApiErrors.NewTimeoutError("for testing", 1)
 


### PR DESCRIPTION
this led to a loop where reconciliation of an addon object updated child namespaces, which in turn enqueued the owning addon object to be reconciled again