### PR TITLE
lowercase olmAllNamespaces and olmOwnNamespaces install option keys

### DIFF
--- a/apis/addons/v1alpha1/addons_types.go
+++ b/apis/addons/v1alpha1/addons_types.go
@@ -27,9 +27,9 @@ type AddonInstallSpec struct {
 	// Type of installation.
 	// +kubebuilder:validation:Enum={"OLMOwnNamespace","OLMAllNamespaces"}
 	Type AddonInstallType `json:"type"`
-	// AllNamespaces config parameters. Present only if Type = OLMAllNamespaces.
+	// OLMAllNamespaces config parameters. Present only if Type = OLMAllNamespaces.
 	OLMAllNamespaces *AddonInstallOLMAllNamespaces `json:"olmAllNamespaces,omitempty"`
-	// OwnNamespace config parameters. Present only if Type = OLMOwnNamespace.
+	// OLMOwnNamespace config parameters. Present only if Type = OLMOwnNamespace.
 	OLMOwnNamespace *AddonInstallOLMOwnNamespace `json:"olmOwnNamespace,omitempty"`
 }
 

--- a/apis/addons/v1alpha1/addons_types.go
+++ b/apis/addons/v1alpha1/addons_types.go
@@ -28,9 +28,9 @@ type AddonInstallSpec struct {
 	// +kubebuilder:validation:Enum={"OLMOwnNamespace","OLMAllNamespaces"}
 	Type AddonInstallType `json:"type"`
 	// AllNamespaces config parameters. Present only if Type = OLMAllNamespaces.
-	OLMAllNamespaces *AddonInstallOLMAllNamespaces `json:"OLMAllNamespaces,omitempty"`
+	OLMAllNamespaces *AddonInstallOLMAllNamespaces `json:"olmAllNamespaces,omitempty"`
 	// OwnNamespace config parameters. Present only if Type = OLMOwnNamespace.
-	OLMOwnNamespace *AddonInstallOLMOwnNamespace `json:"OLMOwnNamespace,omitempty"`
+	OLMOwnNamespace *AddonInstallOLMOwnNamespace `json:"olmOwnNamespace,omitempty"`
 }
 
 // Common Addon installation parameters.

--- a/config/deploy/addons.managed.openshift.io_addons.yaml
+++ b/config/deploy/addons.managed.openshift.io_addons.yaml
@@ -47,7 +47,7 @@ spec:
                 description: 'Defines how an Addon is installed. This field is immutable. TODO: enforce immutablity in webhook'
                 properties:
                   olmAllNamespaces:
-                    description: AllNamespaces config parameters. Present only if Type = OLMAllNamespaces.
+                    description: OLMAllNamespaces config parameters. Present only if Type = OLMAllNamespaces.
                     properties:
                       catalogSourceImage:
                         description: Defines the CatalogSource image. Please only use hashes and no tags here!
@@ -62,7 +62,7 @@ spec:
                     - namespace
                     type: object
                   olmOwnNamespace:
-                    description: OwnNamespace config parameters. Present only if Type = OLMOwnNamespace.
+                    description: OLMOwnNamespace config parameters. Present only if Type = OLMOwnNamespace.
                     properties:
                       catalogSourceImage:
                         description: Defines the CatalogSource image. Please only use hashes and no tags here!

--- a/config/deploy/addons.managed.openshift.io_addons.yaml
+++ b/config/deploy/addons.managed.openshift.io_addons.yaml
@@ -46,7 +46,7 @@ spec:
               install:
                 description: 'Defines how an Addon is installed. This field is immutable. TODO: enforce immutablity in webhook'
                 properties:
-                  OLMAllNamespaces:
+                  olmAllNamespaces:
                     description: AllNamespaces config parameters. Present only if Type = OLMAllNamespaces.
                     properties:
                       catalogSourceImage:
@@ -61,7 +61,7 @@ spec:
                     - catalogSourceImage
                     - namespace
                     type: object
-                  OLMOwnNamespace:
+                  olmOwnNamespace:
                     description: OwnNamespace config parameters. Present only if Type = OLMOwnNamespace.
                     properties:
                       catalogSourceImage:

--- a/config/example/addon.yaml
+++ b/config/example/addon.yaml
@@ -11,8 +11,8 @@ spec:
   - name: additional
   - name: to-be-removed
   install:
-    type: OwnNamespace
-    ownNamespace:
+    type: OLMOwnNamespace
+    olmOwnNamespace:
       namespace: "foo"
   catalogSource:
     # This is the operathub catalog source because (at least for now)


### PR DESCRIPTION
Fixing a little naming nit:

> Acronyms should similarly only be used when extremely commonly known. All letters in the acronym should have the same case, using the appropriate case for the situation. For example, at the beginning of a field name, the acronym should be all lowercase, such as "httpGet". Where used as a constant, all letters should be uppercase, such as "TCP" or "UDP".
>
> https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#naming-conventions

Signed-off-by: Nico Schieder <nschieder@redhat.com>

FYI: @mayankshah1607 