### PR TITLE
Setting explicit integration test timeout to 20m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ test-unit: generate
 ## Runs the Integration testsuite against the current $KUBECONFIG cluster
 test-integration: config/deploy/deployment.yaml
 	@echo "running integration tests..."
-	@go test -v -count=1 ./integration/...
+	@go test -v -count=1 -timeout=20m ./integration/...
 .PHONY: test-integration
 
 # legacy alias for CI/CD


### PR DESCRIPTION
go test has an default timeout of 10m and we have seen some pipelines
trigger that already. This sets the timeout explicitly and increases it
to 20m.

-timeout d
    If a test binary runs longer than duration d, panic.
    If d is 0, the timeout is disabled.
    The default is 10 minutes (10m).
From: https://pkg.go.dev/cmd/go/internal/test

Signed-off-by: Nico Schieder <nschieder@redhat.com>