### PR TITLE
use `go install` instead of `go get` for dependency binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,14 +103,14 @@ FORCE:
 # Dependencies (project local)
 # ----------------------------
 
-# go-get-tool will 'go get' any package $1 if file $2 does not exist.
-define go-get-tool
+# go-install-tool will 'go install' any package $1 if file $2 does not exist.
+define go-install-tool
 @[ -f "$(2)" ] || { \
 	TMP_DIR=$$(mktemp -d); \
 	cd $$TMP_DIR; \
 	go mod init tmp; \
 	echo "Downloading $(1) to $(DEPENDENCIES)/bin"; \
-	GOBIN="$(DEPENDENCY_BIN)" go get "$(1)"; \
+	GOBIN="$(DEPENDENCY_BIN)" go install -mod=readonly "$(1)"; \
 	rm -rf $$TMP_DIR; \
 	mkdir -p "$(dir $(2))"; \
 	touch "$(2)"; \
@@ -119,19 +119,19 @@ endef
 
 KIND:=$(DEPENDENCY_VERSIONS)/kind/$(KIND_VERSION)
 $(KIND):
-	@$(call go-get-tool,sigs.k8s.io/kind@$(KIND_VERSION),$(KIND))
+	@$(call go-install-tool,sigs.k8s.io/kind@$(KIND_VERSION),$(KIND))
 
 CONTROLLER_GEN:=$(DEPENDENCY_VERSIONS)/controller-gen/$(CONTROLLER_GEN_VERSION)
 $(CONTROLLER_GEN):
-	@$(call go-get-tool,sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION),$(CONTROLLER_GEN))
+	@$(call go-install-tool,sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION),$(CONTROLLER_GEN))
 
 YQ:=$(DEPENDENCY_VERSIONS)/yq/$(YQ_VERSION)
 $(YQ):
-	@$(call go-get-tool,github.com/mikefarah/yq/$(YQ_VERSION),$(YQ))
+	@$(call go-install-tool,github.com/mikefarah/yq/$(YQ_VERSION),$(YQ))
 
 GOIMPORTS:=$(DEPENDENCY_VERSIONS)/goimports/$(GOIMPORTS_VERSION)
 $(GOIMPORTS):
-	@$(call go-get-tool,golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION),$(GOIMPORTS))
+	@$(call go-install-tool,golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION),$(GOIMPORTS))
 
 # Setup goimports.
 # alias for goimports to use from `ensure-and-run-goimports.sh` via pre-commit.
@@ -140,7 +140,7 @@ goimports: $(GOIMPORTS)
 
 GOLANGCI_LINT:=$(DEPENDENCY_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT):
-	@$(call go-get-tool,github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION),$(GOLANGCI_LINT))
+	@$(call go-install-tool,github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION),$(GOLANGCI_LINT))
 
 # Setup golangci-lint.
 # alias for golangci-lint to use from `ensure-and-run-golangci-lint.sh` via pre-commit.


### PR DESCRIPTION
go 1.17 deprecated the use of `go get` outside of go modules

> go get prints a deprecation warning when installing commands outside the main module (without the -d flag). go install cmd@version should be used instead to install a command at a specific version, using a suffix like @latest or @v1.2.3. In Go 1.18, the -d flag will always be enabled, and go get will only be used to change dependencies in go.mod.

https://golang.org/doc/go1.17#go-get

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>