### PR TITLE
fix permissions on folder containing kind kubeconfig when it was crea…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,11 +273,14 @@ create-kind-cluster: $(KIND)
 		$$KIND_COMMAND create cluster \
 			--kubeconfig=$(KIND_KUBECONFIG) \
 			--name=$(KIND_CLUSTER_NAME); \
-		if [[ ! -O "$(KIND_KUBECONFIG)" ]]; then \
-			sudo chown $$USER: "$(KIND_KUBECONFIG)"; \
-		fi; \
 		echo; \
 	) 2>&1 | sed 's/^/  /'
+	@if [[ ! -O "$(dir KIND_KUBECONFIG)" ]]; then \
+		sudo chown -R $$USER: "$(KIND_KUBECONFIG)"; \
+	fi
+	@if [[ ! -O "$(KIND_KUBECONFIG)" ]]; then \
+		sudo chown $$USER: "$(KIND_KUBECONFIG)"; \
+	fi
 .PHONY: create-kind-cluster
 
 ## Deletes the previously created kind cluster.


### PR DESCRIPTION
…ted by kind

Kind creates the containing folder for the kubeconfig if it doesn't exist already.
With `sudo kind ...` this results in the folder being owned by rood.
This results `make delete-kind-cluster` not being able to delete the kubeconfig because a user needs write permissions on the folder to delete files from it.

Edit: if you want to test this from a mac or "non-sudo-requiring" linux setup you can apply this diff to `hack/determine-container-runtime.sh` (Be sure to remove the current kind cluster before switching kind users!)
```diff
diff --git a/hack/determine-container-runtime.sh b/hack/determine-container-runtime.sh
index 8118c43..b30cfe8 100644
--- a/hack/determine-container-runtime.sh
+++ b/hack/determine-container-runtime.sh
@@ -13,8 +13,8 @@ function __export_docker() {
     export CONTAINER_COMMAND="sudo docker"
     export KIND_COMMAND="sudo kind"
   else
-    export CONTAINER_COMMAND="docker"
-    export KIND_COMMAND="kind"
+    export CONTAINER_COMMAND="sudo docker"
+    export KIND_COMMAND="sudo kind"
   fi
 }
 
```

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>