### PR TITLE
Fix update after delete errors in reconciler.

### DIFF
--- a/internal/controllers/addon_controller.go
+++ b/internal/controllers/addon_controller.go
@@ -67,21 +67,7 @@ func (r *AddonReconciler) Reconcile(
 	}
 
 	if !addon.DeletionTimestamp.IsZero() {
-		// Clear from CSV Event Handler
-		r.csvEventHandler.Free(addon)
-
-		if controllerutil.ContainsFinalizer(addon, cacheFinalizer) {
-			controllerutil.RemoveFinalizer(addon, cacheFinalizer)
-			if err := r.Update(ctx, addon); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
-			}
-		}
-
-		if addon.Status.Phase == addonsv1alpha1.PhaseTerminating {
-			return ctrl.Result{}, nil
-		}
-
-		return ctrl.Result{}, r.reportTerminationStatus(ctx, addon)
+		return ctrl.Result{}, r.handleAddonDeletion(ctx, addon)
 	}
 
 	// Phase 0.

--- a/internal/controllers/addon_utils_test.go
+++ b/internal/controllers/addon_utils_test.go
@@ -1,0 +1,91 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
+	"github.com/openshift/addon-operator/internal/testutil"
+)
+
+func TestHandleAddonDeletion(t *testing.T) {
+	addonToDelete := &addonsv1alpha1.Addon{
+		ObjectMeta: metav1.ObjectMeta{
+			Finalizers: []string{
+				cacheFinalizer,
+			},
+		},
+	}
+
+	c := testutil.NewClient()
+
+	csvEventHandlerMock := &csvEventHandlerMock{}
+	r := &AddonReconciler{
+		Client:          c,
+		Log:             testutil.NewLogger(t),
+		Scheme:          newTestSchemeWithAddonsv1alpha1(),
+		csvEventHandler: csvEventHandlerMock,
+	}
+
+	c.StatusMock.
+		On("Update", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
+	c.
+		On("Update", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
+	csvEventHandlerMock.
+		On("Free", addonToDelete)
+
+	ctx := context.Background()
+	err := r.handleAddonDeletion(ctx, addonToDelete)
+	require.NoError(t, err)
+
+	assert.Empty(t, addonToDelete.Finalizers)                                    // finalizer is gone
+	assert.Equal(t, addonsv1alpha1.PhaseTerminating, addonToDelete.Status.Phase) // status is set
+}
+
+type csvEventHandlerMock struct {
+	mock.Mock
+}
+
+var _ csvEventHandler = (*csvEventHandlerMock)(nil)
+
+// Create is called in response to an create event - e.g. Pod Creation.
+func (m *csvEventHandlerMock) Create(e event.CreateEvent, q workqueue.RateLimitingInterface) {
+	m.Called(e, q)
+}
+
+// Update is called in response to an update event -  e.g. Pod Updated.
+func (m *csvEventHandlerMock) Update(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	m.Called(e, q)
+}
+
+// Delete is called in response to a delete event - e.g. Pod Deleted.
+func (m *csvEventHandlerMock) Delete(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	m.Called(e, q)
+}
+
+// Generic is called in response to an event of an unknown type or a synthetic event triggered as a cron or
+// external trigger request - e.g. reconcile Autoscaling, or a Webhook.
+func (m *csvEventHandlerMock) Generic(e event.GenericEvent, q workqueue.RateLimitingInterface) {
+	m.Called(e, q)
+}
+
+func (m *csvEventHandlerMock) Free(addon *addonsv1alpha1.Addon) {
+	m.Called(addon)
+}
+
+func (m *csvEventHandlerMock) ReplaceMap(
+	addon *addonsv1alpha1.Addon, csvKeys ...client.ObjectKey,
+) (changed bool) {
+	args := m.Called(addon, csvKeys)
+	return args.Bool(0)
+}


### PR DESCRIPTION
This bug fixes Status updates after object deletion due to the removal
of the finalizer. As soon as the finalizer is removed the object will be
deleted from the kube-apiserver and the status update call fails on
Precondition failed: UID in precondition error.

Note that the Addon is not waiting for all resources to be gone, which
is the default for kubernetes. If clients want to ensure all child
objects are garbage collected and removed, they can use foregroundDeletion.

https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion

Signed-off-by: Nico Schieder <nschieder@redhat.com>