### PR TITLE
Increasing resource requests from 30MiB to 100MiB

### DIFF
--- a/config/deploy/deployment.yaml.tpl
+++ b/config/deploy/deployment.yaml.tpl
@@ -36,7 +36,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 100Mi

--- a/config/olm/addon-operator.csv.tpl.yaml
+++ b/config/olm/addon-operator.csv.tpl.yaml
@@ -184,10 +184,10 @@ spec:
                 resources:
                   limits:
                     cpu: 100m
-                    memory: 30Mi
+                    memory: 100Mi
                   requests:
                     cpu: 100m
-                    memory: 20Mi
+                    memory: 100Mi
       - name: addon-operator-webhook
         spec:
           replicas: 3


### PR DESCRIPTION
Addon Operator already reached 29.95MiB of 30MiB on OSD during testing.
To give us some breathing room, let's push it to 100MiB and put it into
the Guaranteed QoS class, by setting request == limit.

Signed-off-by: Nico Schieder <nschieder@redhat.com>