### PR TITLE
New dockerfile for running pre-commit checks in the CI pipeline

### DIFF
--- a/config/docker/Dockerfile.src.ci
+++ b/config/docker/Dockerfile.src.ci
@@ -1,0 +1,3 @@
+FROM src
+RUN yum update -y && yum install -y python3 python3-pip
+RUN pip3 install pre-commit


### PR DESCRIPTION
Adds a new dockerfile with pre-commit installed which can be used to run pre-commit in the openshift CI/CD.
Signed-off-by: ashish <asnaraya@redhat.com>