### PR TITLE
Add template for OSD onboarding

### DIFF
--- a/config/olm/catalog-source.yaml
+++ b/config/olm/catalog-source.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   sourceType: grpc
   publisher: Red Hat
-  displayName: MTSRE
+  displayName: MTSRE Addon Operator
   image: quay.io/app-sre/addon-operator-index:main

--- a/config/olm/operatorgroup.yaml
+++ b/config/olm/operatorgroup.yaml
@@ -1,5 +1,5 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: reference-addon
+  name: addon-operator
 spec: {}

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: selectorsyncset-template
+
+parameters:
+  - name: REGISTRY_IMG
+    required: true
+  - name: CHANNEL
+    value: staging
+    required: true
+  - name: IMAGE_TAG
+    required: true
+  - name: IMAGE_DIGEST
+    required: true
+  - name: REPO_NAME
+    value: addon-operator
+    required: true
+  - name: DISPLAY_NAME
+    value: Managed Upgrade Operator
+    required: true
+
+objects:
+  - apiVersion: hive.openshift.io/v1
+    kind: SelectorSyncSet
+    metadata:
+      annotations:
+        component-display-name: ${DISPLAY_NAME}
+        component-name: ${REPO_NAME}
+        telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${REPO_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
+      labels:
+        managed.openshift.io/gitHash: ${IMAGE_TAG}
+        managed.openshift.io/gitRepoName: ${REPO_NAME}
+        managed.openshift.io/osd: "true"
+      name: addon-operator
+    spec:
+      clusterDeploymentSelector:
+        matchLabels:
+          api.openshift.com/managed: "true"
+      resourceApplyMode: Sync
+      resources:
+        - apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: openshift-addon-operator
+            labels:
+              openshift.io/cluster-monitoring: "true"
+        - apiVersion: operators.coreos.com/v1alpha1
+          kind: CatalogSource
+          metadata:
+            name: addon-operator-catalog
+            namespace: openshift-addon-operator
+          spec:
+            sourceType: grpc
+            image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
+            displayName: MTSRE Addon Operator
+            publisher: Red Hat
+        - apiVersion: operators.coreos.com/v1
+          kind: OperatorGroup
+          metadata:
+            name: addon-operator-og
+            namespace: openshift-addon-operator
+          spec:
+            targetNamespaces:
+              - openshift-addon-operator
+        - apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: addon-operator
+            namespace: openshift-addon-operator
+          spec:
+            channel: ${CHANNEL}
+            name: addon-operator
+            source: addon-operator-catalog
+            sourceNamespace: openshift-addon-operator


### PR DESCRIPTION
As of [MTSRE-178](https://issues.redhat.com/browse/MTSRE-178):

> Create the Deployment manifests in the addon-operator repository. Example:
> https://github.com/openshift/managed-upgrade-operator/blob/master/hack/olm-registry/olm-artifacts-template.yaml 
