### PR TITLE
remove deprecated use of unauthenticated git:// in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     - --autofix
   - id: trailing-whitespace
 
-- repo: git://github.com/dnephin/pre-commit-golang
+- repo: https://github.com/dnephin/pre-commit-golang
   rev: v0.3.5
   hooks:
   - id: go-fmt


### PR DESCRIPTION
a previous PR check failed with

```
go fmt ./...
golangci-lint run ./... --deadline=15m
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for git://github.com/dnephin/pre-commit-golang.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    fatal: remote error: 
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

> The unauthenticated git protocol on port 9418 is no longer supported.
> Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

this PR replaces all usages of unauthenticated `git://` with `https://`