### PR TITLE
Add run-in-container make target

### DIFF
--- a/config/docker/dev.Dockerfile
+++ b/config/docker/dev.Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.16
+
+RUN apt-get update && apt-get install -y \
+  docker.io \
+  python3-pip \
+  sudo \
+  && rm -rf /var/lib/apt/lists/* && \
+  pip3 install pre-commit


### PR DESCRIPTION
The run-in-container make target will execute the given ARGS="" in a
special development container. This enables some make targets and commadns,
like running container builds on outdated or otherwise strange environments.

This is not working as a development environment replacement as things
like permissions (chown), network access and kind need to be sorted out
seperatly.

Signed-off-by: Nico Schieder <nschieder@redhat.com>