### PR TITLE
Replace webhook image in CSV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,7 @@ setup-addon-operator-crds: generate
 # Template Cluster Service Version / CSV
 # By setting the container image to deploy.
 config/olm/addon-operator.csv.yaml: FORCE $(YQ)
-	@yq eval '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image = "$(ADDON_OPERATOR_MANAGER_IMAGE)" | .metadata.annotations.containerImage = "$(ADDON_OPERATOR_MANAGER_IMAGE)"' \
+	@yq eval '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image = "$(ADDON_OPERATOR_MANAGER_IMAGE)" | .spec.install.spec.deployments[1].spec.template.spec.containers[0].image = "$(ADDON_OPERATOR_WEBHOOK_IMAGE)" | .metadata.annotations.containerImage = "$(ADDON_OPERATOR_MANAGER_IMAGE)"' \
 	config/olm/addon-operator.csv.tpl.yaml > config/olm/addon-operator.csv.yaml
 
 # Bundle image contains the manifests and CSV for a single version of this operator.

--- a/config/olm/addon-operator.csv.tpl.yaml
+++ b/config/olm/addon-operator.csv.tpl.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     repository: https://github.com/openshift/addon-operator
     support: "false"
-    containerImage: +MANAGER_IMAGE_TO_REPLACE+
+    containerImage: quay.io/openshift/addon-operator:latest
     capabilities: Full Lifecycle
   name: addon-operator.v0.1.0
 spec:


### PR DESCRIPTION
The webhook image was not replaced, leading to ImagePullBackoff errors
when installing the AddonOperator. This change replaces the webhook
image name as well to resolve the issue.

Signed-off-by: Nico Schieder <nschieder@redhat.com>