### PR TITLE
[MTSRE-307] Fix Addon phase flapping during initialization

### DIFF
--- a/internal/controllers/addon_operator_utils.go
+++ b/internal/controllers/addon_operator_utils.go
@@ -61,7 +61,6 @@ func (r *AddonOperatorReconciler) reportAddonOperatorPauseStatus(
 		ObservedGeneration: addonOperator.Generation,
 	})
 	addonOperator.Status.ObservedGeneration = addonOperator.Generation
-	addonOperator.Status.Phase = addonsv1alpha1.PhaseReady
 	addonOperator.Status.LastHeartbeatTime = metav1.Now()
 	return r.Status().Update(ctx, addonOperator)
 }
@@ -71,6 +70,5 @@ func (r *AddonOperatorReconciler) removeAddonOperatorPauseCondition(
 	ctx context.Context, addonOperator *addonsv1alpha1.AddonOperator) error {
 	meta.RemoveStatusCondition(&addonOperator.Status.Conditions, addonsv1alpha1.Paused)
 	addonOperator.Status.ObservedGeneration = addonOperator.Generation
-	addonOperator.Status.Phase = addonsv1alpha1.PhaseReady
 	return r.Status().Update(ctx, addonOperator)
 }

--- a/internal/controllers/addon_utils.go
+++ b/internal/controllers/addon_utils.go
@@ -95,7 +95,6 @@ func (r *AddonReconciler) reportAddonPauseStatus(
 		ObservedGeneration: addon.Generation,
 	})
 	addon.Status.ObservedGeneration = addon.Generation
-	addon.Status.Phase = addonsv1alpha1.PhaseReady
 	return r.Status().Update(ctx, addon)
 }
 
@@ -104,7 +103,6 @@ func (r *AddonReconciler) removeAddonPauseCondition(ctx context.Context,
 	addon *addonsv1alpha1.Addon) error {
 	meta.RemoveStatusCondition(&addon.Status.Conditions, addonsv1alpha1.Paused)
 	addon.Status.ObservedGeneration = addon.Generation
-	addon.Status.Phase = addonsv1alpha1.PhaseReady
 	return r.Status().Update(ctx, addon)
 }
 


### PR DESCRIPTION
This change prevents the controller from updating the `Phase` field when reporting pause conditions, hence fixing the flapping issue.

Signed-off-by: Mayank Shah <m.shah@redhat.com>