### PR TITLE
clean up integration test setup and teardown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ export KUBECONFIG?=$(abspath $(KIND_KUBECONFIG))
 export GOLANGCI_LINT_CACHE=$(abspath .cache/golangci-lint)
 export SKIP_TEARDOWN?=
 KIND_CLUSTER_NAME:="addon-operator" # name of the kind cluster for local development.
+ENABLE_API_MOCK?="false"
 ENABLE_WEBHOOK?="false"
 WEBHOOK_PORT?=8080
 
@@ -246,15 +247,14 @@ test-unit: generate
 .PHONY: test-unit
 
 ## Runs the Integration testsuite against the current $KUBECONFIG cluster
-test-integration: config/deploy/deployment.yaml \
-	config/deploy/webhook/deployment.yaml \
-	config/deploy/api-mock/deployment.yaml
+test-integration: export ENABLE_WEBHOOK=true
+test-integration: export ENABLE_API_MOCK=true
+test-integration:
 	@echo "running integration tests..."
 	@go test -v -count=1 -timeout=20m ./integration/...
 .PHONY: test-integration
 
 # legacy alias for CI/CD
-test-e2e: ENABLE_WEBHOOK?=true
 test-e2e: test-integration
 .PHONY: test-e2e
 
@@ -267,8 +267,12 @@ test-integration-short: config/deploy/deployment.yaml \
 # make sure that we install our components into the kind cluster and disregard normal $KUBECONFIG
 test-integration-local: export KUBECONFIG=$(abspath $(KIND_KUBECONFIG))
 ## Setup a local dev environment and execute the full integration testsuite against it.
-test-integration-local: | dev-setup load-addon-operator \
-	load-addon-operator-webhook test-integration
+test-integration-local: | \
+	dev-setup \
+	prepare-addon-operator \
+	prepare-addon-operator-webhook \
+	prepare-api-mock \
+	test-integration
 .PHONY: test-integration-local
 
 # -------------------------
@@ -300,8 +304,7 @@ dev-setup: export KUBECONFIG=$(abspath $(KIND_KUBECONFIG))
 dev-setup: | \
 	create-kind-cluster \
 	setup-olm \
-	setup-okd-console \
-	setup-api-mock
+	setup-okd-console
 .PHONY: dev-setup
 
 ## Setup a local env for integration test development. (Kind, OLM, OKD Console, Addon Operator). Use with test-integration-short.
@@ -370,6 +373,24 @@ setup-okd-console:
 	) 2>&1 | sed 's/^/  /'
 .PHONY: setup-okd-console
 
+## Loads the OCM API Mock into the currently selected cluster.
+prepare-api-mock: \
+	load-api-mock \
+	config/deploy/api-mock/deployment.yaml
+.PHONY: prepare-api-mock
+
+## Loads the Addon Operator Webhook into the currently selected cluster.
+prepare-addon-operator-webhook: \
+	load-addon-operator-webhook \
+	config/deploy/webhook/deployment.yaml
+.PHONY: prepare-addon-operator-webhook
+
+## Loads the Addon Operator into the currently selected cluster.
+prepare-addon-operator: \
+	load-addon-operator \
+	config/deploy/deployment.yaml
+.PHONY: prepare-addon-operator
+
 ## Load Addon Operator images into kind
 load-addon-operator: build-image-addon-operator-manager
 	@source hack/determine-container-runtime.sh; \
@@ -411,10 +432,8 @@ config/deploy/webhook/deployment.yaml: FORCE $(YQ)
 	@yq eval '.spec.ports[0].targetPort = $(WEBHOOK_PORT)' \
 	config/deploy/webhook/service.yaml.tpl > config/deploy/webhook/service.yaml
 
-
 ## Loads and installs the Addon Operator into the currently selected cluster.
-setup-addon-operator: load-addon-operator \
-	config/deploy/deployment.yaml
+setup-addon-operator: prepare-addon-operator
 	@echo "installing Addon Operator $(VERSION)..."
 	@(source hack/determine-container-runtime.sh; \
 		kubectl apply -f config/deploy; \
@@ -423,37 +442,12 @@ setup-addon-operator: load-addon-operator \
 		echo; \
 	) 2>&1 | sed 's/^/  /'
 ifneq ($(ENABLE_WEBHOOK), "false")
-	@make setup-addon-operator-webhook
+	@make prepare-addon-operator-webhook
+endif
+ifneq ($(ENABLE_API_MOCK), "false")
+	@make prepare-api-mock
 endif
 .PHONY: setup-addon-operator
-
-## Loads and installs the OCM API Mock into the currently selected cluster.
-setup-api-mock: load-api-mock \
-	config/deploy/api-mock/deployment.yaml
-	@echo "installing api-mock $(VERSION)..."
-	@(source hack/determine-container-runtime.sh; \
-		kubectl apply -f config/deploy/api-mock; \
-		echo -e "\nwaiting for deployment/api-mock..."; \
-		kubectl wait --for=condition=available deployment/api-mock -n api-mock --timeout=240s; \
-		echo; \
-	) 2>&1 | sed 's/^/  /'
-.PHONY: setup-api-mock
-
-## Loads and installs the Addon Operator Webhook into the currently selected cluster.
-setup-addon-operator-webhook: $(YQ) load-addon-operator-webhook \
-	config/deploy/webhook/deployment.yaml
-	@echo "setting up TLS cert..."
-	@kubectl apply -f \
-		config/deploy/webhook/00-tls-secret.yaml
-	@echo "installing Addon Operator $(VERSION)..."
-	@(source hack/determine-container-runtime.sh; \
-		kubectl apply -f config/deploy/webhook/deployment.yaml; \
-		echo -e "\nwaiting for deployment/addon-operator-webhook..."; \
-		kubectl wait --for=condition=available deployment/addon-operator-webhook -n addon-operator --timeout=240s; \
-		kubectl apply -f config/deploy/webhook/service.yaml; \
-		kubectl apply -f config/deploy/webhook/validatingwebhookconfig.yaml; \
-		echo; \
-	) 2>&1 | sed 's/^/  /'
 
 ## Installs Addon Operator CRDs in to the currently selected cluster.
 setup-addon-operator-crds: generate

--- a/Makefile
+++ b/Makefile
@@ -255,12 +255,15 @@ test-integration:
 .PHONY: test-integration
 
 # legacy alias for CI/CD
-test-e2e: test-integration
+test-e2e: | \
+	config/deploy/deployment.yaml \
+	config/deploy/api-mock/deployment.yaml \
+	config/deploy/webhook/deployment.yaml \
+	test-integration
 .PHONY: test-e2e
 
 ## Runs the Integration testsuite against the current $KUBECONFIG cluster. Skips operator setup and teardown.
-test-integration-short: config/deploy/deployment.yaml \
-	config/deploy/webhook/deployment.yaml
+test-integration-short:
 	@echo "running [short] integration tests..."
 	@go test -v -count=1 -short ./integration/...
 

--- a/integration/addon_test.go
+++ b/integration/addon_test.go
@@ -12,11 +12,9 @@ import (
 
 	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
 	"github.com/openshift/addon-operator/integration"
-	"github.com/openshift/addon-operator/internal/ocm"
 )
 
 func (s *integrationTestSuite) TestAddon() {
-
 	ctx := context.Background()
 
 	addon := addon_OwnNamespace()
@@ -33,13 +31,6 @@ func (s *integrationTestSuite) TestAddon() {
 				a.Status.Conditions, addonsv1alpha1.Available), nil
 		})
 	s.Require().NoError(err)
-
-	s.Run("reports to upgrade policy endpoint", func() {
-		res, err := integration.OCMClient.GetUpgradePolicy(ctx, ocm.UpgradePolicyGetRequest{ID: addon.Spec.UpgradePolicy.ID})
-		s.Require().NoError(err)
-
-		s.Assert().Equal(ocm.UpgradePolicyValueCompleted, res.Value)
-	})
 
 	s.Run("test_namespaces", func() {
 

--- a/integration/fixtures_test.go
+++ b/integration/fixtures_test.go
@@ -30,6 +30,38 @@ var (
 	defaultAddonAvailabilityTimeout = 10 * time.Minute
 )
 
+func addon_OwnNamespace_UpgradePolicyReporting() *addonsv1alpha1.Addon {
+	return &addonsv1alpha1.Addon{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "addon-aefigh1x",
+		},
+		Spec: addonsv1alpha1.AddonSpec{
+			DisplayName: "addon-aefigh1x",
+			Namespaces: []addonsv1alpha1.AddonNamespace{
+				{Name: "namespace-eecu3ou1"},
+				{Name: "namespace-jei9egh2"},
+			},
+			Install: addonsv1alpha1.AddonInstallSpec{
+				Type: addonsv1alpha1.OLMOwnNamespace,
+				OLMOwnNamespace: &addonsv1alpha1.AddonInstallOLMOwnNamespace{
+					AddonInstallOLMCommon: addonsv1alpha1.AddonInstallOLMCommon{
+						Namespace:          "namespace-eecu3ou1",
+						CatalogSourceImage: referenceAddonCatalogSourceImageWorking,
+						Channel:            "alpha",
+						PackageName:        "reference-addon",
+						Config: &addonsv1alpha1.SubscriptionConfig{
+							EnvironmentVariables: referenceAddonConfigEnvObjects,
+						},
+					},
+				},
+			},
+			UpgradePolicy: &addonsv1alpha1.AddonUpgradePolicy{
+				ID: "123-456-789",
+			},
+		},
+	}
+}
+
 func addon_OwnNamespace() *addonsv1alpha1.Addon {
 	return &addonsv1alpha1.Addon{
 		ObjectMeta: v1.ObjectMeta{
@@ -40,9 +72,6 @@ func addon_OwnNamespace() *addonsv1alpha1.Addon {
 			Namespaces: []addonsv1alpha1.AddonNamespace{
 				{Name: "namespace-onbgdions"},
 				{Name: "namespace-pioghfndb"},
-			},
-			UpgradePolicy: &addonsv1alpha1.AddonUpgradePolicy{
-				ID: "123-456-789",
 			},
 			Install: addonsv1alpha1.AddonInstallSpec{
 				Type: addonsv1alpha1.OLMOwnNamespace,

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -176,11 +176,11 @@ func LoadObjectsFromDeploymentFiles(t *testing.T) []unstructured.Unstructured {
 	paths := []string{PathConfigDeploy}
 
 	if testutil.IsApiMockEnabled() {
-		t.Log("api mock is enabled: deploying it")
+		t.Log("api mock is enabled: loading manifests")
 		paths = append(paths, PathOCMAPIMockDeploy)
 	}
 	if testutil.IsWebhookServerEnabled() {
-		t.Log("webhook server is enabled: deploying it")
+		t.Log("webhook server is enabled: loading manifests")
 		paths = append(paths, PathWebhookConfigDeploy)
 	}
 

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -173,10 +173,17 @@ func getFileInfoFromPath(paths []string) ([]fileInfoMap, error) {
 // Load all k8s objects from .yaml files in config/deploy.
 // File/Object order is preserved.
 func LoadObjectsFromDeploymentFiles(t *testing.T) []unstructured.Unstructured {
-	paths := []string{PathConfigDeploy, PathOCMAPIMockDeploy}
+	paths := []string{PathConfigDeploy}
+
+	if testutil.IsApiMockEnabled() {
+		t.Log("api mock is enabled: deploying it")
+		paths = append(paths, PathOCMAPIMockDeploy)
+	}
 	if testutil.IsWebhookServerEnabled() {
+		t.Log("webhook server is enabled: deploying it")
 		paths = append(paths, PathWebhookConfigDeploy)
 	}
+
 	fileInfoMap, err := getFileInfoFromPath(paths)
 	require.NoError(t, err)
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -20,25 +20,6 @@ func (s *integrationTestSuite) SetupSuite() {
 	if !testing.Short() {
 		s.Setup()
 	}
-
-	ctx := context.Background()
-	addonOperator := &addonsv1alpha1.AddonOperator{}
-	if err := integration.Client.Get(ctx, client.ObjectKey{
-		Name: addonsv1alpha1.DefaultAddonOperatorName,
-	}, addonOperator); err != nil {
-		s.T().Fatalf("get AddonOperator object: %v", err)
-	}
-
-	addonOperator.Spec.OCM = &addonsv1alpha1.AddonOperatorOCM{
-		Endpoint: integration.OCMAPIEndpoint,
-		Secret: addonsv1alpha1.ClusterSecretReference{
-			Name:      "api-mock",
-			Namespace: "api-mock",
-		},
-	}
-	if err := integration.Client.Update(ctx, addonOperator); err != nil {
-		s.T().Fatalf("patch AddonOperator object: %v", err)
-	}
 }
 
 func (s *integrationTestSuite) TearDownSuite() {

--- a/integration/ocm_integration_test.go
+++ b/integration/ocm_integration_test.go
@@ -23,6 +23,10 @@ func (s *integrationTestSuite) TestUpgradePolicyReporting() {
 	err := integration.Client.Create(ctx, addon)
 	s.Require().NoError(err)
 
+	s.T().Cleanup(func() {
+		s.addonCleanup(addon, ctx)
+	})
+
 	// wait until Addon is available
 	err = integration.WaitForObject(
 		s.T(), defaultAddonAvailabilityTimeout, addon, "to be Available",

--- a/integration/ocm_integration_test.go
+++ b/integration/ocm_integration_test.go
@@ -1,0 +1,42 @@
+package integration_test
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
+	"github.com/openshift/addon-operator/integration"
+	"github.com/openshift/addon-operator/internal/ocm"
+	"github.com/openshift/addon-operator/internal/testutil"
+)
+
+func (s *integrationTestSuite) TestUpgradePolicyReporting() {
+	if !testutil.IsApiMockEnabled() {
+		s.T().Skip("skipping OCM tests since api mock execution is disabled")
+	}
+
+	ctx := context.Background()
+	addon := addon_OwnNamespace_UpgradePolicyReporting()
+
+	err := integration.Client.Create(ctx, addon)
+	s.Require().NoError(err)
+
+	// wait until Addon is available
+	err = integration.WaitForObject(
+		s.T(), defaultAddonAvailabilityTimeout, addon, "to be Available",
+		func(obj client.Object) (done bool, err error) {
+			a := obj.(*addonsv1alpha1.Addon)
+			return meta.IsStatusConditionTrue(
+				a.Status.Conditions, addonsv1alpha1.Available), nil
+		})
+	s.Require().NoError(err)
+
+	s.Run("reports to upgrade policy endpoint", func() {
+		res, err := integration.OCMClient.GetUpgradePolicy(ctx, ocm.UpgradePolicyGetRequest{ID: addon.Spec.UpgradePolicy.ID})
+		s.Require().NoError(err)
+
+		s.Assert().Equal(ocm.UpgradePolicyValueCompleted, res.Value)
+	})
+}

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -123,7 +123,7 @@ func (s *integrationTestSuite) Setup() {
 		})
 	}
 
-	s.Run("Addon Operator available", func() {
+	s.Run("AddonOperator available", func() {
 		addonOperator := addonsv1alpha1.AddonOperator{}
 
 		// Wait for API to be created
@@ -143,5 +143,25 @@ func (s *integrationTestSuite) Setup() {
 					a.Status.Conditions, addonsv1alpha1.Available), nil
 			})
 		s.Require().NoError(err)
+	})
+
+	s.Run("Patch AddonOperator with OCM mock configuration", func() {
+		addonOperator := &addonsv1alpha1.AddonOperator{}
+		if err := integration.Client.Get(ctx, client.ObjectKey{
+			Name: addonsv1alpha1.DefaultAddonOperatorName,
+		}, addonOperator); err != nil {
+			s.T().Fatalf("get AddonOperator object: %v", err)
+		}
+
+		addonOperator.Spec.OCM = &addonsv1alpha1.AddonOperatorOCM{
+			Endpoint: integration.OCMAPIEndpoint,
+			Secret: addonsv1alpha1.ClusterSecretReference{
+				Name:      "api-mock",
+				Namespace: "api-mock",
+			},
+		}
+		if err := integration.Client.Update(ctx, addonOperator); err != nil {
+			s.T().Fatalf("patch AddonOperator object: %v", err)
+		}
 	})
 }

--- a/integration/teardown_test.go
+++ b/integration/teardown_test.go
@@ -31,7 +31,7 @@ func (s *integrationTestSuite) Teardown() {
 			// Namespaces can take a long time to be cleaned up and
 			// there is no need to be specific about the object kind here
 			o := obj
-			s.Assert().NoError(integration.WaitToBeGone(s.T(), 5*time.Minute, &o))
+			s.Assert().NoError(integration.WaitToBeGone(s.T(), 10*time.Minute, &o))
 		}
 	})
 }

--- a/integration/teardown_test.go
+++ b/integration/teardown_test.go
@@ -31,7 +31,7 @@ func (s *integrationTestSuite) Teardown() {
 			// Namespaces can take a long time to be cleaned up and
 			// there is no need to be specific about the object kind here
 			o := obj
-			s.Assert().NoError(integration.WaitToBeGone(s.T(), 2*time.Minute, &o))
+			s.Assert().NoError(integration.WaitToBeGone(s.T(), 5*time.Minute, &o))
 		}
 	})
 }

--- a/integration/teardown_test.go
+++ b/integration/teardown_test.go
@@ -4,11 +4,23 @@ import (
 	"context"
 	"time"
 
+	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
 	"github.com/openshift/addon-operator/integration"
 )
 
 func (s *integrationTestSuite) Teardown() {
 	ctx := context.Background()
+
+	// assert that all addons are gone before teardown
+	addonList := &addonsv1alpha1.AddonList{}
+	err := integration.Client.List(ctx, addonList)
+	s.Assert().NoError(err)
+	addonNames := []string{}
+	for _, a := range addonList.Items {
+		addonNames = append(addonNames, a.GetName())
+	}
+	s.Assert().Len(addonNames, 0, "expected all Addons to be gone before teardown, but some still exist")
+
 	objs := integration.LoadObjectsFromDeploymentFiles(s.T())
 
 	// reverse object order for de-install
@@ -20,7 +32,7 @@ func (s *integrationTestSuite) Teardown() {
 	for _, obj := range objs {
 		o := obj
 		err := integration.Client.Delete(ctx, &o)
-		s.Require().NoError(err)
+		s.Assert().NoError(err)
 
 		s.T().Log("deleted: ", o.GroupVersionKind().String(),
 			o.GetNamespace()+"/"+o.GetName())

--- a/internal/testutil/common.go
+++ b/internal/testutil/common.go
@@ -45,3 +45,8 @@ func IsWebhookServerEnabled() bool {
 	value, exists := os.LookupEnv("ENABLE_WEBHOOK")
 	return exists && value != "false"
 }
+
+func IsApiMockEnabled() bool {
+	value, exists := os.LookupEnv("ENABLE_API_MOCK")
+	return exists && value != "false"
+}


### PR DESCRIPTION
so that running
- api mock + related tests
- adon webhook + related tests

can be toggled on/off.

I also added a check that asserts that no addon object is in place when test teardown starts.
A failure case looks like this:

```
teardown_test.go:22: 
        	Error Trace:	teardown_test.go:22
        	           				integration_test.go:27
        	           				suite.go:166
        	           				suite.go:177
        	           				integration_test.go:55
        	Error:      	"[addon-aefigh1x]" should have 0 item(s), but has 1
        	Test:       	TestIntegration
        	Messages:   	expected all Addons to be gone before teardown, but some still exist
```

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>
