### PR TITLE
migrate to UBI as a base image

### DIFF
--- a/config/docker/addon-operator-manager.Dockerfile
+++ b/config/docker/addon-operator-manager.Dockerfile
@@ -1,9 +1,20 @@
-FROM scratch
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:16da4d4c5cb289433305050a06834b7328769f8a5257ad5b4a5006465a0379ff
+# registry.access.redhat.com/ubi8/ubi-minimal:8.5-204
+
+# shadow-utils contains adduser and groupadd binaries
+RUN microdnf install shadow-utils \
+	&& groupadd --gid 1000 noroot \
+	&& adduser \
+		--no-create-home \
+		--no-user-group \
+		--uid 1000 \
+		--gid 1000 \
+		noroot
 
 WORKDIR /
-COPY passwd /etc/passwd
-COPY addon-operator-manager /
+
+COPY addon-operator-manager /usr/local/bin/
 
 USER "noroot"
 
-ENTRYPOINT ["/addon-operator-manager"]
+ENTRYPOINT ["/usr/local/bin/addon-operator-manager"]

--- a/config/docker/addon-operator-webhook.Dockerfile
+++ b/config/docker/addon-operator-webhook.Dockerfile
@@ -1,9 +1,20 @@
-FROM scratch
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:16da4d4c5cb289433305050a06834b7328769f8a5257ad5b4a5006465a0379ff
+# registry.access.redhat.com/ubi8/ubi-minimal:8.5-204
+
+# shadow-utils contains adduser and groupadd binaries
+RUN microdnf install shadow-utils \
+	&& groupadd --gid 1000 noroot \
+	&& adduser \
+		--no-create-home \
+		--no-user-group \
+		--uid 1000 \
+		--gid 1000 \
+		noroot
 
 WORKDIR /
-COPY passwd /etc/passwd
-COPY addon-operator-webhook /
+
+COPY addon-operator-webhook /usr/local/bin/
 
 USER "noroot"
 
-ENTRYPOINT ["/addon-operator-webhook"]
+ENTRYPOINT ["/usr/local/bin/addon-operator-webhook"]

--- a/config/docker/api-mock.Dockerfile
+++ b/config/docker/api-mock.Dockerfile
@@ -1,9 +1,20 @@
-FROM scratch
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:16da4d4c5cb289433305050a06834b7328769f8a5257ad5b4a5006465a0379ff
+# registry.access.redhat.com/ubi8/ubi-minimal:8.5-204
+
+# shadow-utils contains adduser and groupadd binaries
+RUN microdnf install shadow-utils \
+	&& groupadd --gid 1000 noroot \
+	&& adduser \
+		--no-create-home \
+		--no-user-group \
+		--uid 1000 \
+		--gid 1000 \
+		noroot
 
 WORKDIR /
-COPY passwd /etc/passwd
-COPY api-mock /
+
+COPY api-mock /usr/local/bin/
 
 USER "noroot"
 
-ENTRYPOINT ["/api-mock"]
+ENTRYPOINT ["/usr/local/bin/api-mock"]

--- a/config/docker/ocm-api-mock.Dockerfile
+++ b/config/docker/ocm-api-mock.Dockerfile
@@ -1,8 +1,19 @@
-FROM scratch
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:16da4d4c5cb289433305050a06834b7328769f8a5257ad5b4a5006465a0379ff
+# registry.access.redhat.com/ubi8/ubi-minimal:8.5-204
+
+# shadow-utils contains adduser and groupadd binaries
+RUN microdnf install shadow-utils \
+	&& groupadd --gid 1000 noroot \
+	&& adduser \
+		--no-create-home \
+		--no-user-group \
+		--uid 1000 \
+		--gid 1000 \
+		noroot
 
 WORKDIR /
-COPY passwd /etc/passwd
-COPY ocm-api-mock /
+
+COPY ocm-api-mock /usr/local/bin/
 
 USER "noroot"
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/MTSRE-362

because images built from scratch do not have a CA trust store which resulted in errors when communicating with the OCM APIs

the passwd file (and copying it around in the Makefile) MUST stay in the repo until we've removed the references in openshift/release

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>