### PR TITLE
MTSRE-412 | check for resource adoption strategy only for resources not owned by addon

### DIFF
--- a/internal/controllers/addon/phase_ensure_catalogsource.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource.go
@@ -98,7 +98,9 @@ func reconcileCatalogSource(ctx context.Context, c client.Client, catalogSource 
 	if !equality.Semantic.DeepEqual(catalogSource.Spec, currentCatalogSource.Spec) ||
 		!controllers.HasEqualControllerReference(catalogSource, currentCatalogSource) {
 		// TODO: remove this condition once resourceAdoptionStrategy is discontinued
-		if strategy != addonsv1alpha1.ResourceAdoptionAdoptAll {
+		// Only enforce resource-adoption check for resources NOT owned by the Addon in the first place.
+		// Note: `catalogSource`'s ownerRef is the Addon.
+		if strategy != addonsv1alpha1.ResourceAdoptionAdoptAll && !controllers.HasEqualControllerReference(catalogSource, currentCatalogSource) {
 			return nil, controllers.ErrNotOwnedByUs
 		}
 		// copy new spec into existing object and update in the k8s api

--- a/internal/controllers/addon/phase_ensure_monitoring_federation.go
+++ b/internal/controllers/addon/phase_ensure_monitoring_federation.go
@@ -126,7 +126,9 @@ func (r *AddonReconciler) reconcileServiceMonitor(
 	if len(currentServiceMonitor.OwnerReferences) == 0 ||
 		!controllers.HasEqualControllerReference(currentServiceMonitor, serviceMonitor) {
 		// TODO: remove this condition once resourceAdoptionStrategy is discontinued
-		if strategy != addonsv1alpha1.ResourceAdoptionAdoptAll {
+		// Only enforce resource-adoption check for resources NOT owned by the Addon in the first place.
+		// Note: `serviceMonitor`'s ownerRef is the Addon.
+		if strategy != addonsv1alpha1.ResourceAdoptionAdoptAll && !controllers.HasEqualControllerReference(currentServiceMonitor, serviceMonitor) {
 			return controllers.ErrNotOwnedByUs
 		}
 	}

--- a/internal/controllers/addon/phase_ensure_operator_group.go
+++ b/internal/controllers/addon/phase_ensure_operator_group.go
@@ -59,7 +59,9 @@ func (r *AddonReconciler) reconcileOperatorGroup(
 	if !equality.Semantic.DeepEqual(currentOperatorGroup.Spec, operatorGroup.Spec) ||
 		!controllers.HasEqualControllerReference(currentOperatorGroup, operatorGroup) {
 		// TODO: remove this condition once resourceAdoptionStrategy is discontinued
-		if strategy != addonsv1alpha1.ResourceAdoptionAdoptAll {
+		// Only enforce resource-adoption check for resources NOT owned by the Addon in the first place.
+		// Note: `operatorGroup`'s ownerRef is the Addon.
+		if strategy != addonsv1alpha1.ResourceAdoptionAdoptAll && !controllers.HasEqualControllerReference(currentOperatorGroup, operatorGroup) {
 			return controllers.ErrNotOwnedByUs
 		}
 		currentOperatorGroup.Spec = operatorGroup.Spec

--- a/internal/controllers/addon/phase_ensure_subscription.go
+++ b/internal/controllers/addon/phase_ensure_subscription.go
@@ -118,13 +118,11 @@ func (r *AddonReconciler) reconcileSubscription(
 	subscription.Spec.InstallPlanApproval = currentSubscription.Spec.InstallPlanApproval
 
 	// only update when spec has changed or owner reference has changed
-	if !equality.Semantic.DeepEqual(
-		subscription.Spec, currentSubscription.Spec) ||
-		!controllers.HasEqualControllerReference(currentSubscription, subscription) {
+	ownedByAddon := controllers.HasEqualControllerReference(currentSubscription, subscription)
+	specChanged := !equality.Semantic.DeepEqual(subscription.Spec, currentSubscription.Spec)
+	if specChanged || !ownedByAddon {
 		// TODO: remove this condition once resourceAdoptionStrategy is discontinued
-		// Only enforce resource-adoption check for resources NOT owned by the Addon in the first place.
-		// Note: `subscription`'s ownerRef is the Addon.
-		if strategy != addonsv1alpha1.ResourceAdoptionAdoptAll && !controllers.HasEqualControllerReference(currentSubscription, subscription) {
+		if strategy != addonsv1alpha1.ResourceAdoptionAdoptAll && !ownedByAddon {
 			return nil, controllers.ErrNotOwnedByUs
 		}
 		// copy new spec into existing object and update in the k8s api

--- a/internal/controllers/addon/phase_ensure_subscription.go
+++ b/internal/controllers/addon/phase_ensure_subscription.go
@@ -122,7 +122,9 @@ func (r *AddonReconciler) reconcileSubscription(
 		subscription.Spec, currentSubscription.Spec) ||
 		!controllers.HasEqualControllerReference(currentSubscription, subscription) {
 		// TODO: remove this condition once resourceAdoptionStrategy is discontinued
-		if strategy != addonsv1alpha1.ResourceAdoptionAdoptAll {
+		// Only enforce resource-adoption check for resources NOT owned by the Addon in the first place.
+		// Note: `subscription`'s ownerRef is the Addon.
+		if strategy != addonsv1alpha1.ResourceAdoptionAdoptAll && !controllers.HasEqualControllerReference(currentSubscription, subscription) {
 			return nil, controllers.ErrNotOwnedByUs
 		}
 		// copy new spec into existing object and update in the k8s api


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <ykukreja@redhat.com>

**Background and Expected Behaviour**

When addon-operator itself creates the sub-resources, like CatalogSources, OperatorGroups, etc., the ownerRef for those sub-resources is set to be the Addon CR. Hence, in those cases, addon-operator should be able to reconcile these objects even if resourceAdoptionStrategy is not specified in the Addon CR (default behaviour: "prevent").

**Bug**

Whenever `resourceAdoptionStrategy` is not set to "AdoptAll", the reconciliation of sub-resources gets blindly blocked even if the Addon CR itself owned those sub-resources.

**Fix**

While starting the reconciliation of sub-resources, addon-operator should only enforce the check of resourceAdoptionStrategy when the ownerRef != Addon CR. This will ensure to block the reconciliation only for objects NOT owned by the Addon CR when the `resourceAdoptionStrategy` gets invalidated.

