### PR TITLE
[MTSRE-412] - Adding units to test for regressions against resourceAdoptionStrategy

### DIFF
--- a/internal/controllers/addon/phase_ensure_subscription_test.go
+++ b/internal/controllers/addon/phase_ensure_subscription_test.go
@@ -1,0 +1,110 @@
+package addon
+
+import (
+	"context"
+	"testing"
+
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
+	"github.com/openshift/addon-operator/internal/controllers"
+	"github.com/openshift/addon-operator/internal/testutil"
+)
+
+func TestEnsureSubscription_Adoption(t *testing.T) {
+	for name, tc := range map[string]struct {
+		MustAdopt  bool
+		Strategy   addonsv1alpha1.ResourceAdoptionStrategyType
+		AssertFunc func(*testing.T, *operatorsv1alpha1.Subscription, error)
+	}{
+		"no strategy/no adoption": {
+			MustAdopt:  false,
+			Strategy:   addonsv1alpha1.ResourceAdoptionStrategyType(""),
+			AssertFunc: assertReconciledSubscription,
+		},
+		"Prevent/no adoption": {
+			MustAdopt:  false,
+			Strategy:   addonsv1alpha1.ResourceAdoptionPrevent,
+			AssertFunc: assertReconciledSubscription,
+		},
+		"AdoptAll/no adoption": {
+			MustAdopt:  false,
+			Strategy:   addonsv1alpha1.ResourceAdoptionAdoptAll,
+			AssertFunc: assertReconciledSubscription,
+		},
+		"no strategy/must adopt": {
+			MustAdopt:  true,
+			Strategy:   addonsv1alpha1.ResourceAdoptionStrategyType(""),
+			AssertFunc: assertUnreconciledSubscription,
+		},
+		"Prevent/must adopt": {
+			MustAdopt:  true,
+			Strategy:   addonsv1alpha1.ResourceAdoptionPrevent,
+			AssertFunc: assertUnreconciledSubscription,
+		},
+		"AdoptAll/must adopt": {
+			MustAdopt:  true,
+			Strategy:   addonsv1alpha1.ResourceAdoptionAdoptAll,
+			AssertFunc: assertReconciledSubscription,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			subscription := testutil.NewTestSubscription()
+
+			c := testutil.NewClient()
+			c.On("Get",
+				testutil.IsContext,
+				testutil.IsObjectKey,
+				testutil.IsOperatorsV1Alpha1SubscriptionPtr,
+			).Run(func(args mock.Arguments) {
+				var sub *operatorsv1alpha1.Subscription
+
+				if tc.MustAdopt {
+					sub = testutil.NewTestSubscriptionWithoutOwner()
+				} else {
+					sub = testutil.NewTestSubscription()
+					// Unrelated spec change to force reconciliation
+					sub.Spec.Channel = "alpha"
+				}
+
+				sub.DeepCopyInto(args.Get(2).(*operatorsv1alpha1.Subscription))
+			}).Return(nil)
+
+			if !tc.MustAdopt || (tc.MustAdopt && tc.Strategy == addonsv1alpha1.ResourceAdoptionAdoptAll) {
+				c.On("Update",
+					testutil.IsContext,
+					testutil.IsOperatorsV1Alpha1SubscriptionPtr,
+					mock.Anything,
+				).Return(nil)
+			}
+
+			rec := AddonReconciler{
+				Client: c,
+				Scheme: testutil.NewTestSchemeWithAddonsv1alpha1(),
+			}
+
+			ctx := context.Background()
+			reconciledSubscription, err := rec.reconcileSubscription(ctx, subscription.DeepCopy(), tc.Strategy)
+
+			tc.AssertFunc(t, reconciledSubscription, err)
+			c.AssertExpectations(t)
+		})
+	}
+}
+
+func assertReconciledSubscription(t *testing.T, sub *operatorsv1alpha1.Subscription, err error) {
+	t.Helper()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, sub)
+
+}
+
+func assertUnreconciledSubscription(t *testing.T, sub *operatorsv1alpha1.Subscription, err error) {
+	t.Helper()
+
+	assert.Error(t, err)
+	assert.EqualError(t, err, controllers.ErrNotOwnedByUs.Error())
+}

--- a/internal/controllers/addon/phase_ensure_wanted_namespaces_test.go
+++ b/internal/controllers/addon/phase_ensure_wanted_namespaces_test.go
@@ -38,7 +38,7 @@ func TestEnsureWantedNamespaces_AddonWithSingleNamespace_Collision(t *testing.T)
 	c := testutil.NewClient()
 	c.On("Get", testutil.IsContext, testutil.IsObjectKey, testutil.IsCoreV1NamespacePtr).Run(func(args mock.Arguments) {
 		arg := args.Get(2).(*corev1.Namespace)
-		testutil.NewTestExistingNamespaceWithOwner().DeepCopyInto(arg)
+		testutil.NewTestExistingNamespace().DeepCopyInto(arg)
 	}).Return(nil)
 	r := &AddonReconciler{
 		Client: c,
@@ -131,7 +131,7 @@ func TestEnsureWantedNamespaces_AddonWithMultipleNamespaces_SingleCollision(t *t
 	c.On("Get", testutil.IsContext, testutil.IsObjectKey, testutil.IsCoreV1NamespacePtr).
 		Run(func(args mock.Arguments) {
 			arg := args.Get(2).(*corev1.Namespace)
-			testutil.NewTestExistingNamespaceWithOwner().DeepCopyInto(arg)
+			testutil.NewTestExistingNamespace().DeepCopyInto(arg)
 		}).
 		Return(nil)
 
@@ -161,7 +161,7 @@ func TestEnsureWantedNamespaces_AddonWithMultipleNamespaces_MultipleCollisions(t
 	c.On("Get", testutil.IsContext, testutil.IsObjectKey, testutil.IsCoreV1NamespacePtr).
 		Run(func(args mock.Arguments) {
 			arg := args.Get(2).(*corev1.Namespace)
-			testutil.NewTestExistingNamespaceWithOwner().DeepCopyInto(arg)
+			testutil.NewTestExistingNamespace().DeepCopyInto(arg)
 		}).
 		Return(nil)
 
@@ -237,52 +237,127 @@ func TestEnsureNamespace_CreateWithLabels(t *testing.T) {
 }
 
 func TestReconcileNamespace_Create(t *testing.T) {
-	c := testutil.NewClient()
-	c.On("Get", testutil.IsContext, testutil.IsObjectKey, testutil.IsCoreV1NamespacePtr).Return(testutil.NewTestErrNotFound())
-	c.On("Create", testutil.IsContext, testutil.IsCoreV1NamespacePtr, mock.Anything).Return(nil, testutil.NewTestNamespace())
+	for name, tc := range map[string]struct {
+		Strategy addonsv1alpha1.ResourceAdoptionStrategyType
+	}{
+		"no adoption strategy": {
+			Strategy: addonsv1alpha1.ResourceAdoptionStrategyType(""),
+		},
+		"Prevent strategy": {
+			Strategy: addonsv1alpha1.ResourceAdoptionPrevent,
+		},
+		"AdoptAll strategy": {
+			Strategy: addonsv1alpha1.ResourceAdoptionAdoptAll,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := testutil.NewClient()
+			c.On("Get", testutil.IsContext, testutil.IsObjectKey, testutil.IsCoreV1NamespacePtr).Return(testutil.NewTestErrNotFound())
+			c.On("Create", testutil.IsContext, testutil.IsCoreV1NamespacePtr, mock.Anything).Return(nil, testutil.NewTestNamespace())
 
-	ctx := context.Background()
-	reconciledNamespace, err := reconcileNamespace(ctx, c, testutil.NewTestNamespace(), addonsv1alpha1.ResourceAdoptionPrevent)
-	require.NoError(t, err)
-	assert.NotNil(t, reconciledNamespace)
-	assert.Equal(t, testutil.NewTestNamespace(), reconciledNamespace)
-	c.AssertExpectations(t)
-	c.AssertCalled(t, "Get", testutil.IsContext, client.ObjectKey{
-		Name: "namespace-1",
-	}, testutil.IsCoreV1NamespacePtr)
-	c.AssertCalled(t, "Create", testutil.IsContext, testutil.NewTestNamespace(), mock.Anything)
+			ctx := context.Background()
+			reconciledNamespace, err := reconcileNamespace(ctx, c, testutil.NewTestNamespace(), tc.Strategy)
+			require.NoError(t, err)
+			assert.NotNil(t, reconciledNamespace)
+			assert.Equal(t, testutil.NewTestNamespace(), reconciledNamespace)
+			c.AssertExpectations(t)
+			c.AssertCalled(t, "Get", testutil.IsContext, client.ObjectKey{
+				Name: "namespace-1",
+			}, testutil.IsCoreV1NamespacePtr)
+			c.AssertCalled(t, "Create", testutil.IsContext, testutil.NewTestNamespace(), mock.Anything)
+		})
+	}
+
 }
 
 func TestReconcileNamespace_CreateWithCollisionWithoutOwner(t *testing.T) {
-	c := testutil.NewClient()
-	c.On("Get", testutil.IsContext, testutil.IsObjectKey, testutil.IsCoreV1NamespacePtr).Run(func(args mock.Arguments) {
-		arg := args.Get(2).(*corev1.Namespace)
-		testutil.NewTestExistingNamespaceWithoutOwner().DeepCopyInto(arg)
-	}).Return(nil)
+	for name, tc := range map[string]struct {
+		Strategy   addonsv1alpha1.ResourceAdoptionStrategyType
+		AssertFunc func(assert.TestingT, error, error, ...interface{}) bool
+	}{
+		"no adoption strategy": {
+			Strategy:   addonsv1alpha1.ResourceAdoptionStrategyType(""),
+			AssertFunc: assert.ErrorIs,
+		},
+		"Prevent strategy": {
+			Strategy:   addonsv1alpha1.ResourceAdoptionPrevent,
+			AssertFunc: assert.ErrorIs,
+		},
+		"AdoptAll strategy": {
+			Strategy:   addonsv1alpha1.ResourceAdoptionAdoptAll,
+			AssertFunc: assert.NotErrorIs,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := testutil.NewClient()
+			c.On("Get", testutil.IsContext, testutil.IsObjectKey, testutil.IsCoreV1NamespacePtr).Run(func(args mock.Arguments) {
+				arg := args.Get(2).(*corev1.Namespace)
+				testutil.NewTestExistingNamespaceWithoutOwner().DeepCopyInto(arg)
+			}).Return(nil)
 
-	ctx := context.Background()
-	_, err := reconcileNamespace(ctx, c, testutil.NewTestNamespace(), addonsv1alpha1.ResourceAdoptionPrevent)
-	require.EqualError(t, err, controllers.ErrNotOwnedByUs.Error())
-	c.AssertExpectations(t)
-	c.AssertCalled(t, "Get", testutil.IsContext, client.ObjectKey{
-		Name: "namespace-1",
-	}, testutil.IsCoreV1NamespacePtr)
+			if tc.Strategy == addonsv1alpha1.ResourceAdoptionAdoptAll {
+				c.On("Update",
+					testutil.IsContext,
+					testutil.IsCoreV1NamespacePtr,
+					mock.Anything,
+				).Return(nil)
+			}
+
+			ctx := context.Background()
+			_, err := reconcileNamespace(ctx, c, testutil.NewTestNamespace(), tc.Strategy)
+
+			tc.AssertFunc(t, err, controllers.ErrNotOwnedByUs)
+			c.AssertExpectations(t)
+			c.AssertCalled(t, "Get", testutil.IsContext, client.ObjectKey{
+				Name: "namespace-1",
+			}, testutil.IsCoreV1NamespacePtr)
+		})
+	}
 }
 
 func TestReconcileNamespace_CreateWithCollisionWithOtherOwner(t *testing.T) {
-	c := testutil.NewClient()
-	c.On("Get", testutil.IsContext, testutil.IsObjectKey, testutil.IsCoreV1NamespacePtr).Run(func(args mock.Arguments) {
-		arg := args.Get(2).(*corev1.Namespace)
-		testutil.NewTestExistingNamespaceWithoutOwner().DeepCopyInto(arg)
-	}).Return(nil)
+	for name, tc := range map[string]struct {
+		Strategy   addonsv1alpha1.ResourceAdoptionStrategyType
+		AssertFunc func(assert.TestingT, error, error, ...interface{}) bool
+	}{
+		"no adoption strategy": {
+			Strategy:   addonsv1alpha1.ResourceAdoptionStrategyType(""),
+			AssertFunc: assert.ErrorIs,
+		},
+		"Prevent strategy": {
+			Strategy:   addonsv1alpha1.ResourceAdoptionPrevent,
+			AssertFunc: assert.ErrorIs,
+		},
+		"AdoptAll strategy": {
+			Strategy:   addonsv1alpha1.ResourceAdoptionAdoptAll,
+			AssertFunc: assert.NotErrorIs,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := testutil.NewClient()
+			c.On("Get", testutil.IsContext, testutil.IsObjectKey, testutil.IsCoreV1NamespacePtr).Run(func(args mock.Arguments) {
+				arg := args.Get(2).(*corev1.Namespace)
+				testutil.NewTestExistingNamespaceWithoutOwner().DeepCopyInto(arg)
+			}).Return(nil)
 
-	ctx := context.Background()
-	_, err := reconcileNamespace(ctx, c, testutil.NewTestNamespace(), addonsv1alpha1.ResourceAdoptionPrevent)
-	require.EqualError(t, err, controllers.ErrNotOwnedByUs.Error())
-	c.AssertExpectations(t)
-	c.AssertCalled(t, "Get", testutil.IsContext, client.ObjectKey{
-		Name: "namespace-1",
-	}, testutil.IsCoreV1NamespacePtr)
+			if tc.Strategy == addonsv1alpha1.ResourceAdoptionAdoptAll {
+				c.On("Update",
+					testutil.IsContext,
+					testutil.IsCoreV1NamespacePtr,
+					mock.Anything,
+				).Return(nil)
+			}
+
+			ctx := context.Background()
+			_, err := reconcileNamespace(ctx, c, testutil.NewTestNamespace(), tc.Strategy)
+
+			tc.AssertFunc(t, err, controllers.ErrNotOwnedByUs)
+			c.AssertExpectations(t)
+			c.AssertCalled(t, "Get", testutil.IsContext, client.ObjectKey{
+				Name: "namespace-1",
+			}, testutil.IsCoreV1NamespacePtr)
+		})
+	}
 }
 
 func TestReconcileNamespace_CreateWithClientError(t *testing.T) {

--- a/internal/controllers/common_utils_test.go
+++ b/internal/controllers/common_utils_test.go
@@ -18,7 +18,7 @@ func TestHasEqualControllerReference(t *testing.T) {
 
 	require.False(t, HasEqualControllerReference(
 		testutil.NewTestNamespace(),
-		testutil.NewTestExistingNamespaceWithOwner(),
+		testutil.NewTestExistingNamespace(),
 	))
 
 	require.False(t, HasEqualControllerReference(

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -5,6 +5,7 @@ import (
 
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sApiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,43 +60,39 @@ func NewTestAddonWithMultipleNamespaces() *addonsv1alpha1.Addon {
 }
 
 func NewTestNamespace() *corev1.Namespace {
+	ns := NewTestNamespaceWithoutOwner()
+	ns.OwnerReferences = testOwnerRefs()
+
+	return ns
+}
+
+func NewTestNamespaceWithoutOwner() *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "namespace-1",
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "foo-apiVersion",
-					Kind:       "foo-kind",
-					Name:       "foo-name",
-					UID:        "foo-uid",
-					Controller: utilpointer.BoolPtr(true),
-				},
-			},
 		},
 	}
+}
+
+func NewTestExistingNamespace() *corev1.Namespace {
+	ns := NewTestExistingNamespaceWithoutOwner()
+	ns.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: "foo-apiVersion-something-else",
+			Kind:       "foo-kind-something-else",
+			Name:       "foo-name-something-else",
+			UID:        "foo-uid-something-else",
+			Controller: utilpointer.BoolPtr(true),
+		},
+	}
+
+	return ns
 }
 
 func NewTestExistingNamespaceWithoutOwner() *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "namespace-1",
-		},
-	}
-}
-
-func NewTestExistingNamespaceWithOwner() *corev1.Namespace {
-	return &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "namespace-1",
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "foo-apiVersion-something-else",
-					Kind:       "foo-kind-something-else",
-					Name:       "foo-name-something-else",
-					UID:        "foo-uid-something-else",
-					Controller: utilpointer.BoolPtr(true),
-				},
-			},
 		},
 	}
 }
@@ -111,20 +108,10 @@ func NewTestErrNotFound() *k8sApiErrors.StatusError {
 }
 
 func NewTestCatalogSource() *operatorsv1alpha1.CatalogSource {
-	return &operatorsv1alpha1.CatalogSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "catalogsource-pfsdboia",
-			Namespace: "default",
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "foo-apiVersion",
-					Kind:       "foo-kind",
-					Name:       "foo-name",
-					UID:        "foo-uid",
-					Controller: utilpointer.BoolPtr(true),
-				},
-			}},
-	}
+	cs := NewTestCatalogSourceWithoutOwner()
+	cs.OwnerReferences = testOwnerRefs()
+
+	return cs
 }
 
 func NewTestCatalogSourceWithoutOwner() *operatorsv1alpha1.CatalogSource {
@@ -137,6 +124,13 @@ func NewTestCatalogSourceWithoutOwner() *operatorsv1alpha1.CatalogSource {
 }
 
 func NewTestOperatorGroup() *operatorsv1.OperatorGroup {
+	og := NewTestOperatorGroupWithoutOwner()
+	og.OwnerReferences = testOwnerRefs()
+
+	return og
+}
+
+func NewTestOperatorGroupWithoutOwner() *operatorsv1.OperatorGroup {
 	return &operatorsv1.OperatorGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testing",
@@ -185,6 +179,51 @@ func NewTestAddonWithCatalogSourceImageWithResourceAdoptionStrategy(strategy add
 				},
 			},
 			ResourceAdoptionStrategy: strategy,
+		},
+	}
+}
+
+func NewTestServiceMonitor() *monitoringv1.ServiceMonitor {
+	sm := NewTestServiceMonitorWithoutOwner()
+	sm.OwnerReferences = testOwnerRefs()
+
+	return sm
+}
+
+func NewTestServiceMonitorWithoutOwner() *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "servicemonitor-abcdefgh",
+			Namespace: "default",
+		},
+	}
+}
+
+func NewTestSubscription() *operatorsv1alpha1.Subscription {
+	sub := NewTestSubscriptionWithoutOwner()
+	sub.OwnerReferences = testOwnerRefs()
+
+	return sub
+}
+
+func NewTestSubscriptionWithoutOwner() *operatorsv1alpha1.Subscription {
+	return &operatorsv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "subscription-abcdefgh",
+			Namespace: "default",
+		},
+		Spec: &operatorsv1alpha1.SubscriptionSpec{},
+	}
+}
+
+func testOwnerRefs() []metav1.OwnerReference {
+	return []metav1.OwnerReference{
+		{
+			APIVersion: "foo-apiVersion",
+			Kind:       "foo-kind",
+			Name:       "foo-name",
+			UID:        "foo-uid",
+			Controller: utilpointer.BoolPtr(true),
 		},
 	}
 }

--- a/internal/testutil/matchers.go
+++ b/internal/testutil/matchers.go
@@ -3,7 +3,9 @@ package testutil
 import (
 	"context"
 
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,7 +20,12 @@ var (
 	IsCoreV1NamespaceListPtr = mock.IsType(&corev1.NamespaceList{})
 
 	// olm
+	IsOperatorsV1OperatorGroupPtr       = mock.IsType(&operatorsv1.OperatorGroup{})
 	IsOperatorsV1Alpha1CatalogSourcePtr = mock.IsType(&operatorsv1alpha1.CatalogSource{})
+	IsOperatorsV1Alpha1SubscriptionPtr  = mock.IsType(&operatorsv1alpha1.Subscription{})
+
+	// prom
+	IsMonitoringV1ServiceMonitorPtr = mock.IsType(&monitoringv1.ServiceMonitor{})
 
 	// addon.managed.openshift.io/v1alpha1
 	IsAddonsv1alpha1AddonPtr             = mock.IsType(&addonsv1alpha1.Addon{})


### PR DESCRIPTION
#### Summary

A previous regression for resourceAdoptionStrategy has been fixed by #128, but that functionality must now be "locked in" with regression tests. The tests added with this PR iterate over the available `ResourceAdoptionStrategy` types, including `""`, and ensures that the strategy is applied as expected and only in instances where the owner refs have changed.

#### Additional Information

- Implementation of the reconciliation method is not consistent amongst phases making it difficult to reuse test code
  In particular, `CatalogSource` has the reconcile function defined outside the reconciler and `Subscription` is only updated when spec changes and not if only the owner refs have been updated.
- Some test helpers were integrated to avoid repetition as well.