### PR TITLE
[MTSRE-425] Refactoring ensureServiceMonitor w/adoption enablement for Service Monitors

### DIFF
--- a/integration/monitoring_federation_test.go
+++ b/integration/monitoring_federation_test.go
@@ -18,7 +18,7 @@ import (
 
 	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
 	"github.com/openshift/addon-operator/integration"
-	"github.com/openshift/addon-operator/internal/controllers"
+	addonctrl "github.com/openshift/addon-operator/internal/controllers/addon"
 )
 
 func (s *integrationTestSuite) TestMonitoringFederation_MonitoringInPlaceAtCreationRemovedAfterwards() {
@@ -75,7 +75,7 @@ func (s *integrationTestSuite) TestMonitoringFederation_MonitoringInPlaceAtCreat
 		})
 	s.Require().NoError(err)
 
-	monitoringNamespaceName := controllers.GetMonitoringNamespaceName(addon)
+	monitoringNamespaceName := addonctrl.GetMonitoringNamespaceName(addon)
 
 	// validate monitoring Namespace
 	currentMonitoringNamespace := &corev1.Namespace{}
@@ -152,7 +152,7 @@ func (s *integrationTestSuite) TestMonitoringFederation_MonitoringNotInPlaceAtCr
 		})
 	s.Require().NoError(err)
 
-	monitoringNamespaceName := controllers.GetMonitoringNamespaceName(addon)
+	monitoringNamespaceName := addonctrl.GetMonitoringNamespaceName(addon)
 
 	// validate that monitoring Namespace is not there
 	{
@@ -198,7 +198,7 @@ func (s *integrationTestSuite) TestMonitoringFederation_MonitoringNotInPlaceAtCr
 }
 
 func validateMonitoringFederationServiceMonitor(t *testing.T, ctx context.Context, addon *addonsv1alpha1.Addon, monitoringNamespaceName string) {
-	serviceMonitorName := controllers.GetMonitoringFederationServiceMonitorName(addon)
+	serviceMonitorName := addonctrl.GetMonitoringFederationServiceMonitorName(addon)
 	currentServiceMonitor := &monitoringv1.ServiceMonitor{}
 	err := integration.Client.Get(ctx, types.NamespacedName{
 		Name:      serviceMonitorName,

--- a/internal/controllers/addon/phase_delete_unwanted_monitoring_federation.go
+++ b/internal/controllers/addon/phase_delete_unwanted_monitoring_federation.go
@@ -26,7 +26,7 @@ func (r *AddonReconciler) ensureDeletionOfUnwantedMonitoringFederation(
 	// A ServiceMonitor is wanted only if .spec.monitoring.federation is set
 	wantedServiceMonitorName := ""
 	if addon.Spec.Monitoring != nil && addon.Spec.Monitoring.Federation != nil {
-		wantedServiceMonitorName = controllers.GetMonitoringFederationServiceMonitorName(addon)
+		wantedServiceMonitorName = GetMonitoringFederationServiceMonitorName(addon)
 	}
 
 	for _, serviceMonitor := range currentServiceMonitors {
@@ -42,7 +42,7 @@ func (r *AddonReconciler) ensureDeletionOfUnwantedMonitoringFederation(
 	}
 
 	if wantedServiceMonitorName == "" {
-		err := ensureNamespaceDeletion(ctx, r.Client, controllers.GetMonitoringNamespaceName(addon))
+		err := ensureNamespaceDeletion(ctx, r.Client, GetMonitoringNamespaceName(addon))
 		if err != nil {
 			return fmt.Errorf("could not remove monitoring federation Namespace: %w", err)
 		}

--- a/internal/controllers/addon/phase_delete_unwanted_monitoring_federation_test.go
+++ b/internal/controllers/addon/phase_delete_unwanted_monitoring_federation_test.go
@@ -30,7 +30,7 @@ func TestEnsureDeletionOfMonitoringFederation_MonitoringFullyMissingInSpec_NotPr
 	c.On("Delete", testutil.IsContext, mock.IsType(&corev1.Namespace{}), mock.Anything).
 		Run(func(args mock.Arguments) {
 			ns := args.Get(1).(*corev1.Namespace)
-			assert.Equal(t, controllers.GetMonitoringNamespaceName(addon), ns.Name)
+			assert.Equal(t, GetMonitoringNamespaceName(addon), ns.Name)
 		}).
 		Return(testutil.NewTestErrNotFound())
 
@@ -97,7 +97,7 @@ func TestEnsureDeletionOfMonitoringFederation_MonitoringFullyMissingInSpec_Prese
 	c.On("Delete", testutil.IsContext, mock.IsType(&corev1.Namespace{}), mock.Anything).
 		Run(func(args mock.Arguments) {
 			ns := args.Get(1).(*corev1.Namespace)
-			assert.Equal(t, controllers.GetMonitoringNamespaceName(addon), ns.Name)
+			assert.Equal(t, GetMonitoringNamespaceName(addon), ns.Name)
 		}).
 		Return(nil)
 
@@ -140,8 +140,8 @@ func TestEnsureDeletionOfMonitoringFederation_MonitoringFullyPresentInSpec_Prese
 		Items: []*monitoringv1.ServiceMonitor{
 			{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      controllers.GetMonitoringFederationServiceMonitorName(addon),
-					Namespace: controllers.GetMonitoringNamespaceName(addon),
+					Name:      GetMonitoringFederationServiceMonitorName(addon),
+					Namespace: GetMonitoringNamespaceName(addon),
 					Labels:    map[string]string{},
 				},
 			},

--- a/internal/controllers/addon/phase_delete_unwanted_namespaces.go
+++ b/internal/controllers/addon/phase_delete_unwanted_namespaces.go
@@ -28,7 +28,7 @@ func (r *AddonReconciler) ensureDeletionOfUnwantedNamespaces(
 
 	// Don't remove monitoring namespace as it will be handled
 	// separately by `phase_delete_unwanted_monitoring_federation`
-	wantedNamespaceNames[controllers.GetMonitoringNamespaceName(addon)] = struct{}{}
+	wantedNamespaceNames[GetMonitoringNamespaceName(addon)] = struct{}{}
 
 	for _, namespace := range currentNamespaces {
 		_, isWanted := wantedNamespaceNames[namespace.Name]

--- a/internal/controllers/common_utils.go
+++ b/internal/controllers/common_utils.go
@@ -1,8 +1,6 @@
 package controllers
 
 import (
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -58,14 +56,4 @@ func HasEqualControllerReference(current, wanted metav1.Object) bool {
 	}
 
 	return false
-}
-
-// Helper function to compute monitoring Namespace name from addon object
-func GetMonitoringNamespaceName(addon *addonsv1alpha1.Addon) string {
-	return fmt.Sprintf("redhat-monitoring-%s", addon.Name)
-}
-
-// Helper function to compute monitoring federation ServiceMonitor name from addon object
-func GetMonitoringFederationServiceMonitorName(addon *addonsv1alpha1.Addon) string {
-	return fmt.Sprintf("federated-sm-%s", addon.Name)
 }


### PR DESCRIPTION
### Summary

The reconciliation phase ensuring that an addon's monitoring federation spec is properly defined in cluster was not "adopting" Service Monitors i.e. updating owner refs. Through fixing this issue a refactor seemed necessary and some other issues were identified/fixed:

- Previous behavior would mark an addon as Pending if the Monitoring Namespace was not in it's active phase, but exit early potentially without error (if status update was success) and proceed with reconciliation. The result of this being that the Service Monitor would not be reconciled and the Addon would be moved back to Available if the reconciliation loop completed subsequent phases successfully.
- `ensureNamespaceWithLables` was not properly applying labels for already owned addons whose labels had changed. Additionally the update was being made with the desired state object rather than the existing object retrieved from the API. This would potentially cause annotations or other fields to be lost. Despite fixing this the behavior was untangled and added directly to `ensureMonitoringNamespace` 1. Because it was likely a premature refactor 2. If for some reason the changes to `ensureNamespaceWithLabels` should be reverted than it's a simpler change.