### PR TITLE
Fix reconcile loop, due to fighting with OLM about namespace labels

### DIFF
--- a/internal/controllers/addon/phase_ensure_wanted_namespaces.go
+++ b/internal/controllers/addon/phase_ensure_wanted_namespaces.go
@@ -93,8 +93,10 @@ func reconcileNamespace(ctx context.Context, c client.Client,
 		return nil, controllers.ErrNotOwnedByUs
 	}
 
+	for k, v := range namespace.Labels {
+		currentNamespace.Labels[k] = v
+	}
 	currentNamespace.OwnerReferences = namespace.OwnerReferences
-	currentNamespace.Labels = namespace.Labels
 
 	return currentNamespace, c.Update(ctx, currentNamespace)
 }


### PR DESCRIPTION
When reconciling an Addon Object, the addon-operator is fighting with OLM over labels of the addon namespace, this can be seen when checking out the logs and seeing an endless stream of reconciles:

```
1.6470146382956882e+09  INFO    controllers.Addon       delaying Addon status reporting to UpgradePolicy endpoint until OCM client is initialized       {"addon": "/reference-addon"}
1.6470146436158235e+09  INFO    controllers.Addon       delaying Addon status reporting to UpgradePolicy endpoint until OCM client is initialized       {"addon": "/reference-addon"}
1.6470146436636653e+09  INFO    controllers.Addon       delaying Addon status reporting to UpgradePolicy endpoint until OCM client is initialized       {"addon": "/reference-addon"}
1.647014643686647e+09   INFO    controllers.Addon       delaying Addon status reporting to UpgradePolicy endpoint until OCM client is initialized       {"addon": "/reference-addon"}
1.6470146478440208e+09  INFO    controllers.Addon       delaying Addon status reporting to UpgradePolicy endpoint until OCM client is initialized       {"addon": "/reference-addon"}
```

OLM is adding a label like this to the namespace:
`olm.operatorgroup.uid/554d0770-758d-4251-bed9-1154dee6efd3: "" `, which we previously did just override, leading to an endless fight...

Signed-off-by: Nico Schieder <nschieder@redhat.com>