### PR TITLE
[MTSRE-528] Fix serviceMonitor bearerTokenFile and make portName configurable.

### DIFF
--- a/apis/addons/v1alpha1/addons_types.go
+++ b/apis/addons/v1alpha1/addons_types.go
@@ -93,6 +93,10 @@ type MonitoringFederationSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	Namespace string `json:"namespace"`
 
+	// The name of the service port fronting the prometheus server.
+	// +kubebuilder:validation:MinLength=1
+	PortName string `json:"portName"`
+
 	// List of series names to federate from the prometheus server.
 	// +listType:set
 	MatchNames []string `json:"matchNames"`

--- a/config/deploy/addons.managed.openshift.io_addons.yaml
+++ b/config/deploy/addons.managed.openshift.io_addons.yaml
@@ -246,10 +246,16 @@ spec:
                         description: Namespace where the prometheus server is running.
                         minLength: 1
                         type: string
+                      portName:
+                        description: The name of the service port fronting the prometheus
+                          server.
+                        minLength: 1
+                        type: string
                     required:
                     - matchLabels
                     - matchNames
                     - namespace
+                    - portName
                     type: object
                 type: object
               namespaces:

--- a/config/openshift/manifests/addons.crd.yaml
+++ b/config/openshift/manifests/addons.crd.yaml
@@ -244,10 +244,16 @@ spec:
                         description: Namespace where the prometheus server is running.
                         minLength: 1
                         type: string
+                      portName:
+                        description: The name of the service port fronting the prometheus
+                          server.
+                        minLength: 1
+                        type: string
                     required:
                     - matchLabels
                     - matchNames
                     - namespace
+                    - portName
                     type: object
                 type: object
               namespaces:

--- a/docs/api-reference/_index.md
+++ b/docs/api-reference/_index.md
@@ -325,6 +325,7 @@ Tracks the last state last reported to the Upgrade Policy endpoint.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | namespace | Namespace where the prometheus server is running. | string | true |
+| portName | The name of the service port fronting the prometheus server. | string | true |
 | matchNames | List of series names to federate from the prometheus server. | []string | true |
 | matchLabels | List of labels used to discover the prometheus server(s) to be federated. | map[string]string | true |
 

--- a/internal/controllers/addon/utils.go
+++ b/internal/controllers/addon/utils.go
@@ -319,13 +319,14 @@ func GetMonitoringFederationServiceMonitorEndpoints(addon *addonsv1alpha1.Addon)
 	}
 
 	return []monitoringv1.Endpoint{{
-		HonorLabels: true,
-		Port:        "9090",
-		Path:        "/federate",
-		Scheme:      "https",
-		Interval:    "30s",
-		TLSConfig:   tlsConfig,
-		Params:      map[string][]string{"match[]": matchParams},
+		BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+		HonorLabels:     true,
+		Port:            addon.Spec.Monitoring.Federation.PortName,
+		Path:            "/federate",
+		Scheme:          "https",
+		Interval:        "30s",
+		TLSConfig:       tlsConfig,
+		Params:          map[string][]string{"match[]": matchParams},
 	}}
 }
 


### PR DESCRIPTION
## Description

Makes portName configurable, also adds bearerTokenFile field.

## golangci-lint

Bumping golangci-lint as `typecheck` linter was failing to properly identify some type methods.