### PR TITLE
Refactor logger to be a part of context

### DIFF
--- a/internal/controllers/addon/controller.go
+++ b/internal/controllers/addon/controller.go
@@ -205,7 +205,7 @@ func (r *AddonReconciler) Reconcile(
 	ctx = controllers.ContextWithLogger(ctx, log)
 
 	addon := &addonsv1alpha1.Addon{}
-	if err := r.Get(controllers.ContextWithLogger(ctx, log), req.NamespacedName, addon); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, addon); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/internal/controllers/addon/controller.go
+++ b/internal/controllers/addon/controller.go
@@ -34,12 +34,6 @@ const (
 	cacheFinalizer        = "addons.managed.openshift.io/cache"
 )
 
-type addonContextKey int
-
-const (
-	addonNamespaceNameKey addonContextKey = iota
-)
-
 type AddonReconciler struct {
 	client.Client
 	Log               logr.Logger
@@ -103,7 +97,6 @@ func NewAddonReconciler(
 			client:          client,
 			scheme:          scheme,
 			csvEventHandler: csvEventHandler,
-			log:             log,
 		},
 	}
 }
@@ -208,13 +201,11 @@ func (r *AddonReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *AddonReconciler) Reconcile(
 	ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
 
-	// inject namespace and name into context for the loggers within the sub-reconcilers
-	// to pick it up.
-	ctx = context.WithValue(ctx, addonNamespaceNameKey, req.NamespacedName.String())
 	log := r.Log.WithValues("addon", req.NamespacedName.String())
+	ctx = controllers.ContextWithLogger(ctx, log)
 
 	addon := &addonsv1alpha1.Addon{}
-	if err := r.Get(ctx, req.NamespacedName, addon); err != nil {
+	if err := r.Get(controllers.ContextWithLogger(ctx, log), req.NamespacedName, addon); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/internal/controllers/addon/phase_ensure_catalogsource.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8sApiErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -23,8 +22,10 @@ const catalogSourcePublisher = "OSD Red Hat Addons"
 // returns an ensureCatalogSourceResult that signals the caller if they have to
 // stop or retry reconciliation of the surrounding Addon resource
 func (r *olmReconciler) ensureCatalogSource(
-	ctx context.Context, log logr.Logger, addon *addonsv1alpha1.Addon,
+	ctx context.Context, addon *addonsv1alpha1.Addon,
 ) (requeueResult, *operatorsv1alpha1.CatalogSource, error) {
+	log := controllers.LoggerFromContext(ctx)
+
 	commonConfig, stop := parseAddonInstallConfig(log, addon)
 	if stop {
 		return resultStop, nil, nil
@@ -82,13 +83,13 @@ func (r *olmReconciler) ensureCatalogSource(
 }
 
 func (r *olmReconciler) ensureAdditionalCatalogSources(
-	ctx context.Context, log logr.Logger, addon *addonsv1alpha1.Addon,
+	ctx context.Context, addon *addonsv1alpha1.Addon,
 ) (requeueResult, error) {
 	if !HasAdditionalCatalogSources(addon) {
 		return resultNil, nil
 	}
 	additionalCatalogSrcs, targetNamespace, pullSecret, stop := parseAddonInstallConfigForAdditionalCatalogSources(
-		log,
+		controllers.LoggerFromContext(ctx),
 		addon,
 	)
 	if stop {

--- a/internal/controllers/addon/phase_ensure_catalogsource_test.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource_test.go
@@ -19,12 +19,12 @@ import (
 func TestReconcileCatalogSource_NotExistingYet_HappyPath(t *testing.T) {
 	c := testutil.NewClient()
 	c.On("Get",
-		testutil.IsContext,
+		mock.Anything,
 		testutil.IsObjectKey,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 	).Return(testutil.NewTestErrNotFound())
 	c.On("Create",
-		testutil.IsContext,
+		mock.Anything,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 		mock.Anything,
 	).Return(nil)
@@ -35,11 +35,11 @@ func TestReconcileCatalogSource_NotExistingYet_HappyPath(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, reconciledCatalogSource)
 	c.AssertExpectations(t)
-	c.AssertCalled(t, "Get", testutil.IsContext, client.ObjectKey{
+	c.AssertCalled(t, "Get", mock.Anything, client.ObjectKey{
 		Name:      catalogSource.Name,
 		Namespace: catalogSource.Namespace,
 	}, testutil.IsOperatorsV1Alpha1CatalogSourcePtr)
-	c.AssertCalled(t, "Create", testutil.IsContext,
+	c.AssertCalled(t, "Create", mock.Anything,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr, mock.Anything)
 }
 
@@ -48,7 +48,7 @@ func TestReconcileCatalogSource_NotExistingYet_WithClientErrorGet(t *testing.T) 
 
 	c := testutil.NewClient()
 	c.On("Get",
-		testutil.IsContext,
+		mock.Anything,
 		testutil.IsObjectKey,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 	).Return(timeoutErr)
@@ -65,12 +65,12 @@ func TestReconcileCatalogSource_NotExistingYet_WithClientErrorCreate(t *testing.
 
 	c := testutil.NewClient()
 	c.On("Get",
-		testutil.IsContext,
+		mock.Anything,
 		testutil.IsObjectKey,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 	).Return(testutil.NewTestErrNotFound())
 	c.On("Create",
-		testutil.IsContext,
+		mock.Anything,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 		mock.Anything,
 	).Return(timeoutErr)
@@ -124,7 +124,7 @@ func TestReconcileCatalogSource_Adoption(t *testing.T) {
 
 			c := testutil.NewClient()
 			c.On("Get",
-				testutil.IsContext,
+				mock.Anything,
 				testutil.IsObjectKey,
 				testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 			).Run(func(args mock.Arguments) {
@@ -143,7 +143,7 @@ func TestReconcileCatalogSource_Adoption(t *testing.T) {
 
 			if !tc.MustAdopt || (tc.MustAdopt && tc.Strategy == addonsv1alpha1.ResourceAdoptionAdoptAll) {
 				c.On("Update",
-					testutil.IsContext,
+					mock.Anything,
 					testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 					mock.Anything,
 				).Return(nil)
@@ -178,13 +178,13 @@ func TestEnsureCatalogSource_Create(t *testing.T) {
 
 	c := testutil.NewClient()
 	c.On("Get",
-		testutil.IsContext,
+		mock.Anything,
 		testutil.IsObjectKey,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 	).Return(testutil.NewTestErrNotFound())
 	var createdCatalogSource *operatorsv1alpha1.CatalogSource
 	c.On("Create",
-		testutil.IsContext,
+		mock.Anything,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 		mock.Anything,
 	).Run(func(args mock.Arguments) {
@@ -215,12 +215,12 @@ func TestEnsureAdditionalCatalogSource_Create(t *testing.T) {
 	addon := testutil.NewTestAddonWithAdditionalCatalogSource()
 	c := testutil.NewClient()
 	c.On("Get",
-		testutil.IsContext,
+		mock.Anything,
 		testutil.IsObjectKey,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 	).Return(testutil.NewTestErrNotFound())
 	c.On("Create",
-		testutil.IsContext,
+		mock.Anything,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 		mock.Anything,
 	).Run(func(args mock.Arguments) {
@@ -248,7 +248,7 @@ func TestEnsureAdditionalCatalogSource_Update(t *testing.T) {
 	addon := testutil.NewTestAddonWithAdditionalCatalogSourceAndResourceAdoptionStrategy(addonsv1alpha1.ResourceAdoptionAdoptAll)
 	c := testutil.NewClient()
 	c.On("Get",
-		testutil.IsContext,
+		mock.Anything,
 		testutil.IsObjectKey,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 	).Run(func(args mock.Arguments) {
@@ -258,7 +258,7 @@ func TestEnsureAdditionalCatalogSource_Update(t *testing.T) {
 		}
 	}).Return(nil)
 	c.On("Update",
-		testutil.IsContext,
+		mock.Anything,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 		mock.Anything,
 	).Return(nil)
@@ -281,7 +281,7 @@ func TestEnsureCatalogSource_Update(t *testing.T) {
 
 	c := testutil.NewClient()
 	c.On("Get",
-		testutil.IsContext,
+		mock.Anything,
 		testutil.IsObjectKey,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 	).Run(func(args mock.Arguments) {
@@ -291,7 +291,7 @@ func TestEnsureCatalogSource_Update(t *testing.T) {
 		}
 	}).Return(nil)
 	c.On("Update",
-		testutil.IsContext,
+		mock.Anything,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 		mock.Anything,
 	).Return(nil)

--- a/internal/controllers/addon/phase_ensure_catalogsource_test.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource_test.go
@@ -202,8 +202,8 @@ func TestEnsureCatalogSource_Create(t *testing.T) {
 
 	log := testutil.NewLogger(t)
 
-	ctx := context.Background()
-	requeueResult, _, err := r.ensureCatalogSource(ctx, log, addon)
+	ctx := controllers.ContextWithLogger(context.Background(), log)
+	requeueResult, _, err := r.ensureCatalogSource(ctx, addon)
 	assert.NoError(t, err)
 	assert.Equal(t, resultNil, requeueResult)
 	if c.AssertExpectations(t) {
@@ -235,9 +235,8 @@ func TestEnsureAdditionalCatalogSource_Create(t *testing.T) {
 	}
 
 	log := testutil.NewLogger(t)
-
-	ctx := context.Background()
-	requeueResult, err := r.ensureAdditionalCatalogSources(ctx, log, addon)
+	ctx := controllers.ContextWithLogger(context.Background(), log)
+	requeueResult, err := r.ensureAdditionalCatalogSources(ctx, addon)
 	assert.NoError(t, err)
 	assert.Equal(t, resultNil, requeueResult)
 	c.AssertExpectations(t)
@@ -268,8 +267,8 @@ func TestEnsureAdditionalCatalogSource_Update(t *testing.T) {
 		scheme: testutil.NewTestSchemeWithAddonsv1alpha1(),
 	}
 	log := testutil.NewLogger(t)
-	ctx := context.Background()
-	requeueResult, err := r.ensureAdditionalCatalogSources(ctx, log, addon)
+	ctx := controllers.ContextWithLogger(context.Background(), log)
+	requeueResult, err := r.ensureAdditionalCatalogSources(ctx, addon)
 	assert.NoError(t, err)
 	assert.Equal(t, resultNil, requeueResult)
 	c.AssertExpectations(t)
@@ -303,9 +302,8 @@ func TestEnsureCatalogSource_Update(t *testing.T) {
 	}
 
 	log := testutil.NewLogger(t)
-
-	ctx := context.Background()
-	requeueResult, _, err := r.ensureCatalogSource(ctx, log, addon)
+	ctx := controllers.ContextWithLogger(context.Background(), log)
+	requeueResult, _, err := r.ensureCatalogSource(ctx, addon)
 	assert.NoError(t, err)
 	assert.Equal(t, resultNil, requeueResult)
 	c.AssertExpectations(t)

--- a/internal/controllers/addon/phase_ensure_operator_group.go
+++ b/internal/controllers/addon/phase_ensure_operator_group.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -19,7 +18,8 @@ import (
 
 // Ensures the presense or absense of an OperatorGroup depending on the Addon install type.
 func (r *olmReconciler) ensureOperatorGroup(
-	ctx context.Context, log logr.Logger, addon *addonsv1alpha1.Addon) (requeueResult, error) {
+	ctx context.Context, addon *addonsv1alpha1.Addon) (requeueResult, error) {
+	log := controllers.LoggerFromContext(ctx)
 	commonConfig, stop := parseAddonInstallConfig(log, addon)
 	if stop {
 		return resultStop, nil

--- a/internal/controllers/addon/phase_ensure_operator_group_test.go
+++ b/internal/controllers/addon/phase_ensure_operator_group_test.go
@@ -110,8 +110,8 @@ func TestEnsureOperatorGroup(t *testing.T) {
 					Return(nil)
 
 				// Test
-				ctx := context.Background()
-				requeueResult, err := r.ensureOperatorGroup(ctx, log, addon)
+				ctx := controllers.ContextWithLogger(context.Background(), log)
+				requeueResult, err := r.ensureOperatorGroup(ctx, addon)
 				require.NoError(t, err)
 				assert.Equal(t, resultNil, requeueResult)
 
@@ -201,8 +201,8 @@ func TestEnsureOperatorGroup(t *testing.T) {
 				}
 
 				// Test
-				ctx := context.Background()
-				requeueResult, err := r.ensureOperatorGroup(ctx, log, test.addon)
+				ctx := controllers.ContextWithLogger(context.Background(), log)
+				requeueResult, err := r.ensureOperatorGroup(ctx, test.addon)
 				require.NoError(t, err)
 				assert.Equal(t, resultStop, requeueResult)
 
@@ -235,8 +235,8 @@ func TestEnsureOperatorGroup(t *testing.T) {
 		}
 
 		// Test
-		ctx := context.Background()
-		requeueResult, err := r.ensureOperatorGroup(ctx, log, addonUnsupported.DeepCopy())
+		ctx := controllers.ContextWithLogger(context.Background(), log)
+		requeueResult, err := r.ensureOperatorGroup(ctx, addonUnsupported.DeepCopy())
 		require.NoError(t, err)
 		assert.Equal(t, resultStop, requeueResult)
 

--- a/internal/controllers/addon/secret_reconciler_test.go
+++ b/internal/controllers/addon/secret_reconciler_test.go
@@ -360,7 +360,7 @@ func TestEnsureSecretPropagation(t *testing.T) {
 		addonOperatorNamespace: "xxx-addon-operator",
 	}
 
-	ctx := context.Background()
+	ctx := controllers.ContextWithLogger(context.Background(), testutil.NewLogger(t))
 	result, err := r.Reconcile(ctx, addon)
 	c.AssertExpectations(t)
 	require.NoError(t, err)
@@ -428,7 +428,7 @@ func TestEnsureSecretPropagation_cleanup_when_nil(t *testing.T) {
 		scheme:                 testutil.NewTestSchemeWithAddonsv1alpha1(),
 		addonOperatorNamespace: "xxx-addon-operator",
 	}
-	ctx := context.Background()
+	ctx := controllers.ContextWithLogger(context.Background(), testutil.NewLogger(t))
 	result, err := r.Reconcile(ctx, addon)
 	c.AssertExpectations(t)
 	require.NoError(t, err)

--- a/internal/controllers/addon/secret_reconciler_test.go
+++ b/internal/controllers/addon/secret_reconciler_test.go
@@ -32,7 +32,7 @@ func TestReconcileSecret_CreateWithClientError(t *testing.T) {
 	timeoutErr := k8sApiErrors.NewTimeoutError("for testing", 1)
 
 	c := testutil.NewClient()
-	c.On("Get", testutil.IsContext,
+	c.On("Get", mock.Anything,
 		testutil.IsObjectKey,
 		mock.IsType(&corev1.Secret{})).
 		Return(timeoutErr)
@@ -42,7 +42,7 @@ func TestReconcileSecret_CreateWithClientError(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, timeoutErr)
 	c.AssertExpectations(t)
-	c.AssertCalled(t, "Get", testutil.IsContext, client.ObjectKey{
+	c.AssertCalled(t, "Get", mock.Anything, client.ObjectKey{
 		Name:      secret.Name,
 		Namespace: secret.Namespace,
 	}, mock.IsType(&corev1.Secret{}))
@@ -73,20 +73,20 @@ func Test_getReferencedPullSecret_uncachedFallback(t *testing.T) {
 	uncachedC := testutil.NewClient()
 	c.
 		On("Get", // get referenced Secret
-			testutil.IsContext,
+			mock.Anything,
 			addonPullSecretKey,
 			mock.IsType(&corev1.Secret{}),
 		).
 		Return(testutil.NewTestErrNotFound())
 	uncachedC.
 		On("Get", // get referenced Secret via uncached read
-			testutil.IsContext,
+			mock.Anything,
 			addonPullSecretKey,
 			mock.IsType(&corev1.Secret{}),
 		).
 		Return(nil)
 	c.On("Patch", // patch referenced Secret to add it to cache
-		testutil.IsContext,
+		mock.Anything,
 		mock.IsType(&corev1.Secret{}),
 		mock.Anything,
 		mock.Anything,
@@ -132,14 +132,14 @@ func Test_getReferencedPullSecret_retry(t *testing.T) {
 	uncachedC := testutil.NewClient()
 	c.
 		On("Get", // get referenced Secret
-			testutil.IsContext,
+			mock.Anything,
 			addonPullSecretKey,
 			mock.IsType(&corev1.Secret{}),
 		).
 		Return(testutil.NewTestErrNotFound())
 	uncachedC.
 		On("Get", // get referenced Secret via uncached read
-			testutil.IsContext,
+			mock.Anything,
 			addonPullSecretKey,
 			mock.IsType(&corev1.Secret{}),
 		).
@@ -182,7 +182,7 @@ func Test_reconcileSecret_CreateWithClientError(t *testing.T) {
 	}
 
 	c := testutil.NewClient()
-	c.On("Get", testutil.IsContext, key, mock.IsType(&corev1.Secret{})).
+	c.On("Get", mock.Anything, key, mock.IsType(&corev1.Secret{})).
 		Return(timeoutErr)
 
 	ctx := context.Background()
@@ -206,10 +206,10 @@ func Test_reconcileSecret_Create(t *testing.T) {
 
 	c := testutil.NewClient()
 	c.
-		On("Get", testutil.IsContext, key, mock.IsType(&corev1.Secret{})).
+		On("Get", mock.Anything, key, mock.IsType(&corev1.Secret{})).
 		Return(k8sApiErrors.NewNotFound(schema.GroupResource{}, ""))
 	c.
-		On("Create", testutil.IsContext, secret, mock.Anything).
+		On("Create", mock.Anything, secret, mock.Anything).
 		Return(nil)
 
 	ctx := context.Background()
@@ -236,11 +236,11 @@ func Test_reconcileSecret_Update(t *testing.T) {
 
 	c := testutil.NewClient()
 	c.
-		On("Get", testutil.IsContext, key, mock.IsType(&corev1.Secret{})).
+		On("Get", mock.Anything, key, mock.IsType(&corev1.Secret{})).
 		Return(nil)
 	var updatedSecret *corev1.Secret
 	c.
-		On("Update", testutil.IsContext, mock.IsType(&corev1.Secret{}), mock.Anything).
+		On("Update", mock.Anything, mock.IsType(&corev1.Secret{}), mock.Anything).
 		Run(func(args mock.Arguments) {
 			updatedSecret = args.Get(1).(*corev1.Secret)
 		}).
@@ -302,7 +302,7 @@ func TestEnsureSecretPropagation(t *testing.T) {
 	}
 	srcSecret1Key := client.ObjectKeyFromObject(srcSecret1)
 	c.
-		On("Get", testutil.IsContext, srcSecret1Key, mock.IsType(&corev1.Secret{})).
+		On("Get", mock.Anything, srcSecret1Key, mock.IsType(&corev1.Secret{})).
 		Run(func(args mock.Arguments) {
 			out := args.Get(2).(*corev1.Secret)
 			*out = *srcSecret1
@@ -314,11 +314,11 @@ func TestEnsureSecretPropagation(t *testing.T) {
 		Namespace: "test",
 	}
 	c.
-		On("Get", testutil.IsContext, destSecret1Key, mock.IsType(&corev1.Secret{})).
+		On("Get", mock.Anything, destSecret1Key, mock.IsType(&corev1.Secret{})).
 		Return(k8sApiErrors.NewNotFound(schema.GroupResource{}, ""))
 	var createdDestSecret *corev1.Secret
 	c.
-		On("Create", testutil.IsContext, mock.IsType(&corev1.Secret{}), mock.Anything).
+		On("Create", mock.Anything, mock.IsType(&corev1.Secret{}), mock.Anything).
 		Run(func(args mock.Arguments) {
 			createdDestSecret = args.Get(1).(*corev1.Secret)
 		}).
@@ -331,7 +331,7 @@ func TestEnsureSecretPropagation(t *testing.T) {
 		},
 	}
 	c.
-		On("List", testutil.IsContext, mock.IsType(&corev1.SecretList{}), mock.Anything).
+		On("List", mock.Anything, mock.IsType(&corev1.SecretList{}), mock.Anything).
 		Run(func(args mock.Arguments) {
 			out := args.Get(1).(*corev1.SecretList)
 			*out = corev1.SecretList{
@@ -351,7 +351,7 @@ func TestEnsureSecretPropagation(t *testing.T) {
 		}).
 		Return(nil)
 	c.
-		On("Delete", testutil.IsContext, secretToDelete, mock.Anything).
+		On("Delete", mock.Anything, secretToDelete, mock.Anything).
 		Return(nil)
 
 	r := &addonSecretPropagationReconciler{
@@ -407,7 +407,7 @@ func TestEnsureSecretPropagation_cleanup_when_nil(t *testing.T) {
 		},
 	}
 	c.
-		On("List", testutil.IsContext, mock.IsType(&corev1.SecretList{}), mock.Anything).
+		On("List", mock.Anything, mock.IsType(&corev1.SecretList{}), mock.Anything).
 		Run(func(args mock.Arguments) {
 			out := args.Get(1).(*corev1.SecretList)
 			*out = corev1.SecretList{
@@ -420,7 +420,7 @@ func TestEnsureSecretPropagation_cleanup_when_nil(t *testing.T) {
 		}).
 		Return(nil)
 	c.
-		On("Delete", testutil.IsContext, secretToDelete, mock.Anything).
+		On("Delete", mock.Anything, secretToDelete, mock.Anything).
 		Return(nil)
 
 	r := &addonSecretPropagationReconciler{

--- a/internal/controllers/context.go
+++ b/internal/controllers/context.go
@@ -1,0 +1,26 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+)
+
+type controllerContextKey int
+
+const loggerContextKey controllerContextKey = iota
+
+// Add a logger to the given context, to make it easier passing it around.
+func ContextWithLogger(parent context.Context, logger logr.Logger) context.Context {
+	return context.WithValue(context.Background(), loggerContextKey, logger)
+}
+
+// Get the logger from the given context.
+// Returning a discarding logger, if none was set.
+func LoggerFromContext(ctx context.Context) logr.Logger {
+	logger, ok := ctx.Value(loggerContextKey).(logr.Logger)
+	if ok {
+		return logger
+	}
+	return logr.Discard()
+}


### PR DESCRIPTION
putting the logger directly into the context object, so it's available everywhere and we don't have to pass it explicitly anymore.
In the future, we can also add additional properties like a tracing id via the same way.

Signed-off-by: Nico Schieder <nschieder@redhat.com>