### PR TITLE
refactor: merge sub-reconcilers into a single slice of sub-reconcilers

### DIFF
--- a/internal/controllers/addon/addon_instance_reconciler.go
+++ b/internal/controllers/addon/addon_instance_reconciler.go
@@ -17,6 +17,8 @@ import (
 	"github.com/openshift/addon-operator/internal/controllers"
 )
 
+const ADDON_INSTANCE_RECONCILER_NAME = "addonInstanceReconciler"
+
 type addonInstanceReconciler struct {
 	client client.Client
 	scheme *runtime.Scheme
@@ -29,6 +31,10 @@ func (r *addonInstanceReconciler) Reconcile(ctx context.Context,
 		return ctrl.Result{}, fmt.Errorf("failed to ensure the creation of addoninstance: %w", err)
 	}
 	return reconcile.Result{}, nil
+}
+
+func (r *addonInstanceReconciler) Name() string {
+	return ADDON_INSTANCE_RECONCILER_NAME
 }
 
 // Ensures the presence of an AddonInstance well-compliant with the provided Addon object

--- a/internal/controllers/addon/addon_instance_reconciler_test.go
+++ b/internal/controllers/addon/addon_instance_reconciler_test.go
@@ -88,9 +88,9 @@ func TestEnsureAddonInstance(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				log := testutil.NewLogger(t)
 				c := testutil.NewClient()
-				r := AddonReconciler{
-					Client: c,
-					Scheme: testutil.NewTestSchemeWithAddonsv1alpha1(),
+				r := addonInstanceReconciler{
+					client: c,
+					scheme: testutil.NewTestSchemeWithAddonsv1alpha1(),
 				}
 				addon := test.addon
 
@@ -142,7 +142,8 @@ func TestEnsureAddonInstance(t *testing.T) {
 
 				// Test
 				ctx := context.Background()
-				err := r.ensureAddonInstance(ctx, log, addon)
+				controllers.ContextWithLogger(ctx, log)
+				err := r.ensureAddonInstance(ctx, addon)
 				require.NoError(t, err)
 
 				assert.Equal(t, addonsv1alpha1.DefaultAddonInstanceName, createdAddonInstance.Name)
@@ -230,14 +231,15 @@ func TestEnsureAddonInstance(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				log := testutil.NewLogger(t)
 				c := testutil.NewClient()
-				r := AddonReconciler{
-					Client: c,
-					Scheme: testutil.NewTestSchemeWithAddonsv1alpha1(),
+				r := addonInstanceReconciler{
+					client: c,
+					scheme: testutil.NewTestSchemeWithAddonsv1alpha1(),
 				}
 
 				// Test
 				ctx := context.Background()
-				err := r.ensureAddonInstance(ctx, log, test.addon)
+				controllers.ContextWithLogger(ctx, log)
+				err := r.ensureAddonInstance(ctx, test.addon)
 				require.EqualError(t, err, "failed to create addonInstance due to misconfigured install.spec.type")
 
 				// check Addon Status
@@ -268,9 +270,9 @@ func TestReconcileAddonInstance(t *testing.T) {
 
 	t.Run("no addoninstance", func(t *testing.T) {
 		c := testutil.NewClient()
-		r := AddonReconciler{
-			Client: c,
-			Scheme: testutil.NewTestSchemeWithAddonsv1alpha1(),
+		r := addonInstanceReconciler{
+			client: c,
+			scheme: testutil.NewTestSchemeWithAddonsv1alpha1(),
 		}
 
 		c.
@@ -293,9 +295,9 @@ func TestReconcileAddonInstance(t *testing.T) {
 
 	t.Run("update", func(t *testing.T) {
 		c := testutil.NewClient()
-		r := AddonReconciler{
-			Client: c,
-			Scheme: testutil.NewTestSchemeWithAddonsv1alpha1(),
+		r := addonInstanceReconciler{
+			client: c,
+			scheme: testutil.NewTestSchemeWithAddonsv1alpha1(),
 		}
 
 		c.

--- a/internal/controllers/addon/controller.go
+++ b/internal/controllers/addon/controller.go
@@ -3,6 +3,7 @@ package addon
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
@@ -51,10 +52,10 @@ type AddonReconciler struct {
 	ocmClient    ocmClient
 	ocmClientMux sync.RWMutex
 
-	secretPropagationReconciler    addonReconciler
-	namespaceReconciler            addonReconciler
-	olmReconciler                  addonReconciler
-	monitoringFederationReconciler addonReconciler
+	// List of Addon sub-reconcilers.
+	// Reconcilers will run in the order in which
+	// they appear in this slice.
+	subReconcilers []addonReconciler
 }
 
 type addonReconciler interface {
@@ -81,27 +82,35 @@ func NewAddonReconciler(
 		AddonOperatorNamespace: addonOperatorNamespace,
 		csvEventHandler:        csvEventHandler,
 
-		secretPropagationReconciler: &addonSecretPropagationReconciler{
-			cachedClient:           client,
-			uncachedClient:         uncachedClient,
-			scheme:                 scheme,
-			addonOperatorNamespace: addonOperatorNamespace,
-		},
-
-		namespaceReconciler: &namespaceReconciler{
-			client: client,
-			scheme: scheme,
-		},
-
-		olmReconciler: &olmReconciler{
-			client:          client,
-			scheme:          scheme,
-			csvEventHandler: csvEventHandler,
-		},
-
-		monitoringFederationReconciler: &monitoringFederationReconciler{
-			client: client,
-			scheme: scheme,
+		subReconcilers: []addonReconciler{
+			// Step 1: Reconcile Namespace
+			&namespaceReconciler{
+				client: client,
+				scheme: scheme,
+			},
+			// Step 2: Reconcile Addon pull secrets
+			&addonSecretPropagationReconciler{
+				cachedClient:           client,
+				uncachedClient:         uncachedClient,
+				scheme:                 scheme,
+				addonOperatorNamespace: addonOperatorNamespace,
+			},
+			// Step 3: Reconcile AddonInstance object
+			&addonInstanceReconciler{
+				client: client,
+				scheme: scheme,
+			},
+			// Step 4: Reconcile OLM objects
+			&olmReconciler{
+				client:          client,
+				scheme:          scheme,
+				csvEventHandler: csvEventHandler,
+			},
+			// Step 5: Reconcile Monitoring Federation
+			&monitoringFederationReconciler{
+				client: client,
+				scheme: scheme,
+			},
 		},
 	}
 }
@@ -259,7 +268,6 @@ func (r *AddonReconciler) Reconcile(
 	// Make sure Pause condition is removed
 	r.removeAddonPauseCondition(addon)
 
-	// Phase 0.
 	// Ensure cache finalizer
 	if !controllerutil.ContainsFinalizer(addon, cacheFinalizer) {
 		controllerutil.AddFinalizer(addon, cacheFinalizer)
@@ -268,37 +276,14 @@ func (r *AddonReconciler) Reconcile(
 		}
 	}
 
-	// Reconcile Namespace
-	if result, err := r.namespaceReconciler.Reconcile(ctx, addon); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to reconcile namespace: %w", err)
-	} else if !result.IsZero() {
-		return result, nil
-	}
-
-	// Reconcile addon pullsecrets
-	if result, err := r.secretPropagationReconciler.Reconcile(ctx, addon); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to ensure pull secret: %w", err)
-	} else if !result.IsZero() {
-		return result, nil
-	}
-
-	// Ensure the creation of the corresponding AddonInstance in .spec.install.olmOwnNamespace/.spec.install.olmAllNamespaces namespace
-	if err := r.ensureAddonInstance(ctx, log, addon); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to ensure the creation of addoninstance: %w", err)
-	}
-
-	// Reconciler OLM objects
-	if result, err := r.olmReconciler.Reconcile(ctx, addon); err != nil {
-		return ctrl.Result{}, err
-	} else if !result.IsZero() {
-		return result, nil
-	}
-
-	// Reconcile monitoring objects
-	if result, err := r.monitoringFederationReconciler.Reconcile(ctx, addon); err != nil {
-		return ctrl.Result{}, err
-	} else if !result.IsZero() {
-		return result, nil
+	// Run each sub reconciler serially
+	for _, reconciler := range r.subReconcilers {
+		reconcilerType := reflect.TypeOf(reconciler).Elem()
+		if result, err := reconciler.Reconcile(ctx, addon); err != nil {
+			return ctrl.Result{}, fmt.Errorf("%s - failed to reconcile: %w", reconcilerType, err)
+		} else if !result.IsZero() {
+			return result, nil
+		}
 	}
 
 	// After last phase and if everything is healthy

--- a/internal/controllers/addon/monitoring_federation_reconciler.go
+++ b/internal/controllers/addon/monitoring_federation_reconciler.go
@@ -21,6 +21,8 @@ import (
 	"github.com/openshift/addon-operator/internal/controllers"
 )
 
+const MONITORING_FEDERATION_RECONCILER_NAME = "monitoringFederationReconciler"
+
 type monitoringFederationReconciler struct {
 	client client.Client
 	scheme *runtime.Scheme
@@ -48,6 +50,10 @@ func (r *monitoringFederationReconciler) Reconcile(ctx context.Context,
 		return ctrl.Result{}, fmt.Errorf("failed to ensure deletion of unwanted ServiceMonitors: %w", err)
 	}
 	return reconcile.Result{}, nil
+}
+
+func (r *monitoringFederationReconciler) Name() string {
+	return MONITORING_FEDERATION_RECONCILER_NAME
 }
 
 // ensureMonitoringFederation inspects an addon's MonitoringFederation specification

--- a/internal/controllers/addon/namespace_reconciler.go
+++ b/internal/controllers/addon/namespace_reconciler.go
@@ -19,6 +19,8 @@ import (
 	"github.com/openshift/addon-operator/internal/controllers"
 )
 
+const NAMESPACE_RECONCILER_NAME = "namespaceReconciler"
+
 type namespaceReconciler struct {
 	client client.Client
 	scheme *runtime.Scheme
@@ -38,6 +40,10 @@ func (r *namespaceReconciler) Reconcile(ctx context.Context,
 		return ctrl.Result{}, fmt.Errorf("failed to ensure deletion of unwanted Namespaces: %w", err)
 	}
 	return reconcile.Result{}, nil
+}
+
+func (r *namespaceReconciler) Name() string {
+	return NAMESPACE_RECONCILER_NAME
 }
 
 // Ensure cleanup of Namespaces that are not needed anymore for the given Addon resource

--- a/internal/controllers/addon/olm_reconciler.go
+++ b/internal/controllers/addon/olm_reconciler.go
@@ -14,6 +14,8 @@ import (
 	"github.com/openshift/addon-operator/internal/controllers"
 )
 
+const OLM_RECONCILER_NAME = "olmReconciler"
+
 type olmReconciler struct {
 	scheme          *runtime.Scheme
 	client          client.Client
@@ -73,4 +75,8 @@ func (r *olmReconciler) Reconcile(ctx context.Context,
 		return handleExit(requeueResult), nil
 	}
 	return reconcile.Result{}, nil
+}
+
+func (r *olmReconciler) Name() string {
+	return OLM_RECONCILER_NAME
 }

--- a/internal/controllers/addon/secret_reconciler.go
+++ b/internal/controllers/addon/secret_reconciler.go
@@ -16,6 +16,8 @@ import (
 	"github.com/openshift/addon-operator/internal/controllers"
 )
 
+const SECRET_RECONCILER_NAME = "secretPropogationReconciler"
+
 // Sub-Reconciler taking care of secret propagation.
 type addonSecretPropagationReconciler struct {
 	cachedClient, uncachedClient client.Client
@@ -48,6 +50,10 @@ func (r *addonSecretPropagationReconciler) Reconcile(ctx context.Context, addon 
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *addonSecretPropagationReconciler) Name() string {
+	return SECRET_RECONCILER_NAME
 }
 
 // Lookup all secret sources for secret propagation


### PR DESCRIPTION
AddonReconciler now accepts a list of sub-reconcilers, each that run serially in the order in which the appear. This reduces some redundant code.

Signed-off-by: Mayank Shah <m.shah@redhat.com>