### PR TITLE
Remove adoption runtime configuration CatalogSource and Subscription 

### DIFF
--- a/internal/controllers/addon/phase_ensure_catalogsource.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource.go
@@ -144,7 +144,7 @@ func (r *olmReconciler) ensureAdditionalCatalogSources(
 	return resultNil, nil
 }
 
-// reconciles a CatalogSource and returns a new CatalogSource object with observed state.
+// reconciles a CatalogSource and returns a new CatalogSource object with updated state.
 // Warning: Will adopt existing CatalogSource
 func reconcileCatalogSource(ctx context.Context, c client.Client, catalogSource *operatorsv1alpha1.CatalogSource) (
 	*operatorsv1alpha1.CatalogSource, error) {

--- a/internal/controllers/addon/phase_ensure_catalogsource.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource.go
@@ -58,7 +58,7 @@ func (r *olmReconciler) ensureCatalogSource(
 	var observedCatalogSource *operatorsv1alpha1.CatalogSource
 	{
 		var err error
-		observedCatalogSource, err = reconcileCatalogSource(ctx, r.client, catalogSource, addon.Spec.ResourceAdoptionStrategy)
+		observedCatalogSource, err = reconcileCatalogSource(ctx, r.client, catalogSource)
 		if err != nil {
 			return resultNil, nil, err
 		}
@@ -121,7 +121,7 @@ func (r *olmReconciler) ensureAdditionalCatalogSources(
 		}
 		var observedCatalogSource *operatorsv1alpha1.CatalogSource
 		var err error
-		observedCatalogSource, err = reconcileCatalogSource(ctx, r.client, currentCatalogSrc, addon.Spec.ResourceAdoptionStrategy)
+		observedCatalogSource, err = reconcileCatalogSource(ctx, r.client, currentCatalogSrc)
 		if err != nil {
 			return resultNil, err
 		}
@@ -146,7 +146,7 @@ func (r *olmReconciler) ensureAdditionalCatalogSources(
 
 // reconciles a CatalogSource and returns a new CatalogSource object with observed state.
 // Warning: Will adopt existing CatalogSource
-func reconcileCatalogSource(ctx context.Context, c client.Client, catalogSource *operatorsv1alpha1.CatalogSource, strategy addonsv1alpha1.ResourceAdoptionStrategyType) (
+func reconcileCatalogSource(ctx context.Context, c client.Client, catalogSource *operatorsv1alpha1.CatalogSource) (
 	*operatorsv1alpha1.CatalogSource, error) {
 	currentCatalogSource := &operatorsv1alpha1.CatalogSource{}
 
@@ -163,17 +163,14 @@ func reconcileCatalogSource(ctx context.Context, c client.Client, catalogSource 
 		}
 	}
 
-	// only update when spec or ownerReference has changed
+	// only update when spec or labels have changed or when adopting (not already owned by addon controller)
 	ownedByAddon := controllers.HasEqualControllerReference(currentCatalogSource, catalogSource)
 	specChanged := !equality.Semantic.DeepEqual(catalogSource.Spec, currentCatalogSource.Spec)
 	currentLabels := labels.Set(currentCatalogSource.Labels)
-	newLabels := labels.Merge(currentLabels, labels.Set(catalogSource.Labels))
+	newLabels := labels.Merge(currentLabels, catalogSource.Labels)
 
 	if specChanged || !ownedByAddon || !labels.Equals(newLabels, currentLabels) {
-		// TODO: remove this condition once resourceAdoptionStrategy is discontinued
-		if strategy != addonsv1alpha1.ResourceAdoptionAdoptAll && !ownedByAddon {
-			return nil, controllers.ErrNotOwnedByUs
-		}
+
 		// copy new spec into existing object and update in the k8s api
 		currentCatalogSource.Spec = catalogSource.Spec
 		currentCatalogSource.OwnerReferences = catalogSource.OwnerReferences

--- a/internal/controllers/addon/phase_ensure_catalogsource.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource.go
@@ -167,7 +167,7 @@ func reconcileCatalogSource(ctx context.Context, c client.Client, catalogSource 
 	ownedByAddon := controllers.HasEqualControllerReference(currentCatalogSource, catalogSource)
 	specChanged := !equality.Semantic.DeepEqual(catalogSource.Spec, currentCatalogSource.Spec)
 	currentLabels := labels.Set(currentCatalogSource.Labels)
-	newLabels := labels.Merge(currentLabels, catalogSource.Labels)
+	newLabels := labels.Merge(currentLabels, labels.Set(catalogSource.Labels))
 	if specChanged || !ownedByAddon || !labels.Equals(newLabels, currentLabels) {
 		currentCatalogSource.Spec = catalogSource.Spec
 		currentCatalogSource.OwnerReferences = catalogSource.OwnerReferences

--- a/internal/controllers/addon/phase_ensure_catalogsource.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource.go
@@ -163,15 +163,12 @@ func reconcileCatalogSource(ctx context.Context, c client.Client, catalogSource 
 		}
 	}
 
-	// only update when spec or labels have changed or when adopting (not already owned by addon controller)
+	// Only update when spec, controllerRef, or labels have changed
 	ownedByAddon := controllers.HasEqualControllerReference(currentCatalogSource, catalogSource)
 	specChanged := !equality.Semantic.DeepEqual(catalogSource.Spec, currentCatalogSource.Spec)
 	currentLabels := labels.Set(currentCatalogSource.Labels)
 	newLabels := labels.Merge(currentLabels, catalogSource.Labels)
-
 	if specChanged || !ownedByAddon || !labels.Equals(newLabels, currentLabels) {
-
-		// copy new spec into existing object and update in the k8s api
 		currentCatalogSource.Spec = catalogSource.Spec
 		currentCatalogSource.OwnerReferences = catalogSource.OwnerReferences
 		currentCatalogSource.Labels = newLabels

--- a/internal/controllers/addon/phase_ensure_catalogsource_test.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource_test.go
@@ -2,8 +2,9 @@ package addon
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -161,11 +162,11 @@ func TestEnsureCatalogSource_Create(t *testing.T) {
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 		mock.Anything,
 	).Run(func(args mock.Arguments) {
-		arg := args.Get(1).(*operatorsv1alpha1.CatalogSource)
-		arg.Status.GRPCConnectionState = &operatorsv1alpha1.GRPCConnectionState{
+		catalogSource := args.Get(1).(*operatorsv1alpha1.CatalogSource)
+		catalogSource.Status.GRPCConnectionState = &operatorsv1alpha1.GRPCConnectionState{
 			LastObservedState: "READY",
 		}
-		createdCatalogSource = arg
+		createdCatalogSource = catalogSource
 	}).Return(nil)
 
 	r := &olmReconciler{
@@ -197,8 +198,8 @@ func TestEnsureAdditionalCatalogSource_Create(t *testing.T) {
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 		mock.Anything,
 	).Run(func(args mock.Arguments) {
-		arg := args.Get(1).(*operatorsv1alpha1.CatalogSource)
-		arg.Status.GRPCConnectionState = &operatorsv1alpha1.GRPCConnectionState{
+		catalogSource := args.Get(1).(*operatorsv1alpha1.CatalogSource)
+		catalogSource.Status.GRPCConnectionState = &operatorsv1alpha1.GRPCConnectionState{
 			LastObservedState: "READY",
 		}
 	}).Return(nil)
@@ -225,8 +226,8 @@ func TestEnsureAdditionalCatalogSource_Update(t *testing.T) {
 		testutil.IsObjectKey,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 	).Run(func(args mock.Arguments) {
-		arg := args.Get(2).(*operatorsv1alpha1.CatalogSource)
-		arg.Status.GRPCConnectionState = &operatorsv1alpha1.GRPCConnectionState{
+		currentCatalogSource := args.Get(2).(*operatorsv1alpha1.CatalogSource)
+		currentCatalogSource.Status.GRPCConnectionState = &operatorsv1alpha1.GRPCConnectionState{
 			LastObservedState: "READY",
 		}
 	}).Return(nil)
@@ -258,8 +259,8 @@ func TestEnsureCatalogSource_Update(t *testing.T) {
 		testutil.IsObjectKey,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 	).Run(func(args mock.Arguments) {
-		arg := args.Get(2).(*operatorsv1alpha1.CatalogSource)
-		arg.Status.GRPCConnectionState = &operatorsv1alpha1.GRPCConnectionState{
+		currentCatalogSource := args.Get(2).(*operatorsv1alpha1.CatalogSource)
+		currentCatalogSource.Status.GRPCConnectionState = &operatorsv1alpha1.GRPCConnectionState{
 			LastObservedState: "READY",
 		}
 	}).Return(nil)
@@ -277,6 +278,7 @@ func TestEnsureCatalogSource_Update(t *testing.T) {
 	log := testutil.NewLogger(t)
 	ctx := controllers.ContextWithLogger(context.Background(), log)
 	requeueResult, _, err := r.ensureCatalogSource(ctx, addon)
+
 	assert.NoError(t, err)
 	assert.Equal(t, resultNil, requeueResult)
 	c.AssertExpectations(t)

--- a/internal/controllers/addon/phase_ensure_catalogsource_test.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource_test.go
@@ -91,8 +91,8 @@ func TestReconcileCatalogSource_Adoption(t *testing.T) {
 		testutil.IsObjectKey,
 		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
 	).Run(func(args mock.Arguments) {
-		currentCatalogSource := testutil.NewTestCatalogSourceWithoutOwner()
-		currentCatalogSource.DeepCopyInto(args.Get(2).(*operatorsv1alpha1.CatalogSource))
+		catalogSourceWithoutOwner := testutil.NewTestCatalogSourceWithoutOwner()
+		catalogSourceWithoutOwner.DeepCopyInto(args.Get(2).(*operatorsv1alpha1.CatalogSource))
 	}).Return(nil)
 
 	c.On("Update",

--- a/internal/controllers/addon/phase_ensure_catalogsource_test.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource_test.go
@@ -111,41 +111,6 @@ func TestReconcileCatalogSource_Adoption(t *testing.T) {
 	c.AssertExpectations(t)
 }
 
-func TestReconcileCatalogSource_UpdateOnSpecChange(t *testing.T) {
-	const newConfigMapName = "new-config-map"
-	const oldConfigMapName = "old-config-map"
-
-	catalogSource := testutil.NewTestCatalogSource()
-	catalogSource.Spec.ConfigMap = newConfigMapName
-
-	c := testutil.NewClient()
-
-	c.On("Get",
-		mock.Anything,
-		testutil.IsObjectKey,
-		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
-	).Run(func(args mock.Arguments) {
-		currentCatalogSource := testutil.NewTestCatalogSource()
-		currentCatalogSource.Spec.ConfigMap = oldConfigMapName
-		currentCatalogSource.DeepCopyInto(args.Get(2).(*operatorsv1alpha1.CatalogSource))
-	}).Return(nil)
-
-	c.On("Update",
-		mock.Anything,
-		testutil.IsOperatorsV1Alpha1CatalogSourcePtr,
-		mock.Anything,
-	).Return(nil)
-
-	ctx := context.Background()
-
-	reconciledCatalogSource, err := reconcileCatalogSource(ctx, c, catalogSource.DeepCopy())
-
-	assert.NoError(t, err)
-	assert.NotNil(t, reconciledCatalogSource)
-	assert.Equal(t, newConfigMapName, reconciledCatalogSource.Spec.ConfigMap)
-	c.AssertExpectations(t)
-}
-
 func TestEnsureCatalogSource_Create(t *testing.T) {
 	addon := testutil.NewTestAddonWithCatalogSourceImage()
 

--- a/internal/controllers/addon/phase_ensure_subscription.go
+++ b/internal/controllers/addon/phase_ensure_subscription.go
@@ -119,8 +119,8 @@ func (r *olmReconciler) reconcileSubscription(
 	// Only update when spec, controllerRef, or labels have changed
 	specChanged := !equality.Semantic.DeepEqual(subscription.Spec, currentSubscription.Spec)
 	ownedByAddon := controllers.HasEqualControllerReference(currentSubscription, subscription)
-	currentLabels := currentSubscription.Labels
-	newLabels := labels.Merge(currentLabels, subscription.Labels)
+	currentLabels := labels.Set(currentSubscription.Labels)
+	newLabels := labels.Merge(currentLabels, labels.Set(subscription.Labels))
 	if specChanged || !ownedByAddon || !labels.Equals(currentLabels, newLabels) {
 		currentSubscription.Spec = subscription.Spec
 		currentSubscription.OwnerReferences = subscription.OwnerReferences

--- a/internal/controllers/addon/phase_ensure_subscription.go
+++ b/internal/controllers/addon/phase_ensure_subscription.go
@@ -3,6 +3,7 @@ package addon
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -115,18 +116,18 @@ func (r *olmReconciler) reconcileSubscription(
 	// keep installPlanApproval value of existing object
 	subscription.Spec.InstallPlanApproval = currentSubscription.Spec.InstallPlanApproval
 
-	// only update when spec or labels has changed
+	// Only update when spec, controllerRef, or labels have changed
 	specChanged := !equality.Semantic.DeepEqual(subscription.Spec, currentSubscription.Spec)
 	ownedByAddon := controllers.HasEqualControllerReference(currentSubscription, subscription)
 	currentLabels := currentSubscription.Labels
 	newLabels := labels.Merge(currentLabels, subscription.Labels)
 	if specChanged || !ownedByAddon || !labels.Equals(currentLabels, newLabels) {
-		// copy new spec into existing object and update in the k8s api
 		currentSubscription.Spec = subscription.Spec
 		currentSubscription.OwnerReferences = subscription.OwnerReferences
 		currentSubscription.Labels = newLabels
 		return currentSubscription, r.client.Update(ctx, currentSubscription)
 	}
+
 	return currentSubscription, nil
 }
 

--- a/internal/controllers/addon/phase_ensure_subscription_test.go
+++ b/internal/controllers/addon/phase_ensure_subscription_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 
+	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
 	"github.com/openshift/addon-operator/internal/testutil"
 )
 

--- a/internal/controllers/addon/phase_ensure_subscription_test.go
+++ b/internal/controllers/addon/phase_ensure_subscription_test.go
@@ -2,8 +2,9 @@ package addon
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -42,7 +43,7 @@ func TestEnsureSubscription_Adoption(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, reconciledSubscription)
-	assert.True(t, equality.Semantic.DeepEqual(reconciledSubscription.OwnerReferences, reconciledSubscription.OwnerReferences))
+	assert.True(t, equality.Semantic.DeepEqual(subscription.OwnerReferences, reconciledSubscription.OwnerReferences))
 	c.AssertExpectations(t)
 
 }

--- a/internal/controllers/addon/phase_ensure_subscription_test.go
+++ b/internal/controllers/addon/phase_ensure_subscription_test.go
@@ -24,8 +24,8 @@ func TestEnsureSubscription_Adoption(t *testing.T) {
 		testutil.IsObjectKey,
 		testutil.IsOperatorsV1Alpha1SubscriptionPtr,
 	).Run(func(args mock.Arguments) {
-		currentSubscription := testutil.NewTestSubscriptionWithoutOwner()
-		currentSubscription.DeepCopyInto(args.Get(2).(*operatorsv1alpha1.Subscription))
+		subscriptionWithoutOwner := testutil.NewTestSubscriptionWithoutOwner()
+		subscriptionWithoutOwner.DeepCopyInto(args.Get(2).(*operatorsv1alpha1.Subscription))
 	}).Return(nil)
 
 	c.On("Update",

--- a/internal/controllers/addon/phase_ensure_subscription_test.go
+++ b/internal/controllers/addon/phase_ensure_subscription_test.go
@@ -2,6 +2,7 @@ package addon
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"testing"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -9,105 +10,41 @@ import (
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 
-	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
-	"github.com/openshift/addon-operator/internal/controllers"
 	"github.com/openshift/addon-operator/internal/testutil"
 )
 
 func TestEnsureSubscription_Adoption(t *testing.T) {
-	for name, tc := range map[string]struct {
-		MustAdopt  bool
-		Strategy   addonsv1alpha1.ResourceAdoptionStrategyType
-		AssertFunc func(*testing.T, *operatorsv1alpha1.Subscription, error)
-	}{
-		"no strategy/no adoption": {
-			MustAdopt:  false,
-			Strategy:   addonsv1alpha1.ResourceAdoptionStrategyType(""),
-			AssertFunc: assertReconciledSubscription,
-		},
-		"Prevent/no adoption": {
-			MustAdopt:  false,
-			Strategy:   addonsv1alpha1.ResourceAdoptionPrevent,
-			AssertFunc: assertReconciledSubscription,
-		},
-		"AdoptAll/no adoption": {
-			MustAdopt:  false,
-			Strategy:   addonsv1alpha1.ResourceAdoptionAdoptAll,
-			AssertFunc: assertReconciledSubscription,
-		},
-		"no strategy/must adopt": {
-			MustAdopt:  true,
-			Strategy:   addonsv1alpha1.ResourceAdoptionStrategyType(""),
-			AssertFunc: assertUnreconciledSubscription,
-		},
-		"Prevent/must adopt": {
-			MustAdopt:  true,
-			Strategy:   addonsv1alpha1.ResourceAdoptionPrevent,
-			AssertFunc: assertUnreconciledSubscription,
-		},
-		"AdoptAll/must adopt": {
-			MustAdopt:  true,
-			Strategy:   addonsv1alpha1.ResourceAdoptionAdoptAll,
-			AssertFunc: assertReconciledSubscription,
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			subscription := testutil.NewTestSubscription()
+	subscription := testutil.NewTestSubscription()
 
-			c := testutil.NewClient()
-			c.On("Get",
-				testutil.IsContext,
-				testutil.IsObjectKey,
-				testutil.IsOperatorsV1Alpha1SubscriptionPtr,
-			).Run(func(args mock.Arguments) {
-				var sub *operatorsv1alpha1.Subscription
+	c := testutil.NewClient()
+	c.On("Get",
+		testutil.IsContext,
+		testutil.IsObjectKey,
+		testutil.IsOperatorsV1Alpha1SubscriptionPtr,
+	).Run(func(args mock.Arguments) {
+		currentSubscription := testutil.NewTestSubscriptionWithoutOwner()
+		currentSubscription.DeepCopyInto(args.Get(2).(*operatorsv1alpha1.Subscription))
+	}).Return(nil)
 
-				if tc.MustAdopt {
-					sub = testutil.NewTestSubscriptionWithoutOwner()
-				} else {
-					sub = testutil.NewTestSubscription()
-					// Unrelated spec change to force reconciliation
-					sub.Spec.Channel = "alpha"
-				}
+	c.On("Update",
+		testutil.IsContext,
+		testutil.IsOperatorsV1Alpha1SubscriptionPtr,
+		mock.Anything,
+	).Return(nil)
 
-				sub.DeepCopyInto(args.Get(2).(*operatorsv1alpha1.Subscription))
-			}).Return(nil)
-
-			if !tc.MustAdopt || (tc.MustAdopt && tc.Strategy == addonsv1alpha1.ResourceAdoptionAdoptAll) {
-				c.On("Update",
-					testutil.IsContext,
-					testutil.IsOperatorsV1Alpha1SubscriptionPtr,
-					mock.Anything,
-				).Return(nil)
-			}
-
-			rec := olmReconciler{
-				client: c,
-				scheme: testutil.NewTestSchemeWithAddonsv1alpha1(),
-			}
-
-			ctx := context.Background()
-			reconciledSubscription, err := rec.reconcileSubscription(ctx, subscription.DeepCopy(), tc.Strategy)
-
-			tc.AssertFunc(t, reconciledSubscription, err)
-			c.AssertExpectations(t)
-		})
+	rec := olmReconciler{
+		client: c,
+		scheme: testutil.NewTestSchemeWithAddonsv1alpha1(),
 	}
-}
 
-func assertReconciledSubscription(t *testing.T, sub *operatorsv1alpha1.Subscription, err error) {
-	t.Helper()
+	ctx := context.Background()
+	reconciledSubscription, err := rec.reconcileSubscription(ctx, subscription.DeepCopy())
 
 	assert.NoError(t, err)
-	assert.NotNil(t, sub)
+	assert.NotNil(t, reconciledSubscription)
+	assert.True(t, equality.Semantic.DeepEqual(reconciledSubscription.OwnerReferences, reconciledSubscription.OwnerReferences))
+	c.AssertExpectations(t)
 
-}
-
-func assertUnreconciledSubscription(t *testing.T, sub *operatorsv1alpha1.Subscription, err error) {
-	t.Helper()
-
-	assert.Error(t, err)
-	assert.EqualError(t, err, controllers.ErrNotOwnedByUs.Error())
 }
 
 func TestCreateSubscriptionConfigObject(t *testing.T) {

--- a/internal/controllers/common_utils.go
+++ b/internal/controllers/common_utils.go
@@ -59,8 +59,8 @@ func HasEqualControllerReference(current, wanted metav1.Object) bool {
 	wantedOwnerRefs := wanted.GetOwnerReferences()
 
 	for _, ownerRef := range wantedOwnerRefs {
-		// OwnerRef is the same if UIDs match
-		if currentControllerRef.UID == ownerRef.UID {
+		// OwnerRef's are the same if UIDs match
+		if ownerRef.UID == currentControllerRef.UID {
 			return true
 		}
 	}

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -163,7 +163,7 @@ func NewTestAddonWithCatalogSourceImage() *addonsv1alpha1.Addon {
 	}
 }
 
-func NewTestAddonWithAdditionalCatalogSource() *addonsv1alpha1.Addon {
+func NewTestAddonWithAdditionalCatalogSources() *addonsv1alpha1.Addon {
 	return &addonsv1alpha1.Addon{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "addon-1",
@@ -187,57 +187,6 @@ func NewTestAddonWithAdditionalCatalogSource() *addonsv1alpha1.Addon {
 					},
 				},
 			},
-		},
-	}
-}
-
-func NewTestAddonWithAdditionalCatalogSourceAndResourceAdoptionStrategy(
-	strategy addonsv1alpha1.ResourceAdoptionStrategyType) *addonsv1alpha1.Addon {
-	return &addonsv1alpha1.Addon{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "addon-1",
-			UID:  "addon-uid",
-		},
-		Spec: addonsv1alpha1.AddonSpec{
-			Install: addonsv1alpha1.AddonInstallSpec{
-				Type: addonsv1alpha1.OLMOwnNamespace,
-				OLMOwnNamespace: &addonsv1alpha1.AddonInstallOLMOwnNamespace{
-					AddonInstallOLMCommon: addonsv1alpha1.AddonInstallOLMCommon{
-						AdditionalCatalogSources: []addonsv1alpha1.AdditionalCatalogSource{
-							{
-								Name:  "test-1",
-								Image: "test-image-1",
-							},
-							{
-								Name:  "test-2",
-								Image: "test-image-2",
-							},
-						},
-					},
-				},
-			},
-			ResourceAdoptionStrategy: strategy,
-		},
-	}
-}
-
-func NewTestAddonWithCatalogSourceImageWithResourceAdoptionStrategy(strategy addonsv1alpha1.ResourceAdoptionStrategyType) *addonsv1alpha1.Addon {
-	return &addonsv1alpha1.Addon{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "addon-1",
-			UID:  "addon-uid",
-		},
-		Spec: addonsv1alpha1.AddonSpec{
-			Install: addonsv1alpha1.AddonInstallSpec{
-				Type: addonsv1alpha1.OLMOwnNamespace,
-				OLMOwnNamespace: &addonsv1alpha1.AddonInstallOLMOwnNamespace{
-					AddonInstallOLMCommon: addonsv1alpha1.AddonInstallOLMCommon{
-						CatalogSourceImage: "quay.io/osd-addons/test:sha256:04864220677b2ed6244f2e0d421166df908986700647595ffdb6fd9ca4e5098a",
-						Namespace:          "addon-1",
-					},
-				},
-			},
-			ResourceAdoptionStrategy: strategy,
 		},
 	}
 }


### PR DESCRIPTION
Remove adoption runtime configuration for CatalogSource and Subscription 
https://issues.redhat.com/secure/RapidBoard.jspa?rapidView=8694&projectKey=MTSRE&view=detail&selectedIssue=[MTSRE-565](https://issues.redhat.com//browse/MTSRE-565)