### PR TITLE
Added unit test for HasAdoptAllStrategy function

### DIFF
--- a/internal/controllers/addon/utils_test.go
+++ b/internal/controllers/addon/utils_test.go
@@ -805,3 +805,46 @@ func TestHasMonitoringFederation(t *testing.T) {
 		})
 	}
 }
+
+func TestHasAdoptAllStrategy(t *testing.T) {
+	testCases := []struct {
+		addon          *addonsv1alpha1.Addon
+		expectedResult bool
+	}{
+		{
+			addon:          &addonsv1alpha1.Addon{},
+			expectedResult: false,
+		},
+		{
+			addon: &addonsv1alpha1.Addon{
+				Spec: addonsv1alpha1.AddonSpec{
+					ResourceAdoptionStrategy: "invalid",
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			addon: &addonsv1alpha1.Addon{
+				Spec: addonsv1alpha1.AddonSpec{
+					ResourceAdoptionStrategy: addonsv1alpha1.ResourceAdoptionPrevent,
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			addon: &addonsv1alpha1.Addon{
+				Spec: addonsv1alpha1.AddonSpec{
+					ResourceAdoptionStrategy: addonsv1alpha1.ResourceAdoptionAdoptAll,
+				},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("test has adopt all strategy", func(t *testing.T) {
+			result := HasAdoptAllStrategy(tc.addon)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ankit Kurmi <akurmi@redhat.com>

## Description

Adding unit test for `HasAdoptAllStrategy` function under `internal/controllers/addon/utils.go` which checks if an addon has `ResourceAdoptionAdoptAll` strategy.