### PR TITLE
Some nit fixes to redundant assignment

### DIFF
--- a/internal/controllers/addon/utils.go
+++ b/internal/controllers/addon/utils.go
@@ -99,9 +99,6 @@ func reportTerminationStatus(addon *addonsv1alpha1.Addon) {
 
 // Report Addon status to communicate that the resource is misconfigured
 func reportConfigurationError(addon *addonsv1alpha1.Addon, message string) {
-	// TODO: remove the following 2 lines of code
-	addon.Status.ObservedGeneration = addon.Generation
-	addon.Status.Phase = addonsv1alpha1.PhaseError
 	meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
 		Type:    addonsv1alpha1.Available,
 		Status:  metav1.ConditionFalse,


### PR DESCRIPTION
Signed-off-by: Ankit Kurmi <akurmi@redhat.com>

## Description

Some nit fixes to redundant assignment to `reportConfigurationError` function under `internal/controllers/addon/utils.go` :)