### PR TITLE
OSD-12071 Add annotation to disable global namespace resolution

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Template
 metadata:
   name: selectorsyncset-template
-
 parameters:
   - name: REGISTRY_IMG
     required: true
@@ -19,7 +18,6 @@ parameters:
   - name: OCM_BASE_URL
     value: http://api-mock.api-mock.svc.cluster.local
     required: true
-
 objects:
   - apiVersion: hive.openshift.io/v1
     kind: SelectorSyncSet
@@ -60,6 +58,8 @@ objects:
           metadata:
             name: addon-operator-og
             namespace: openshift-addon-operator
+            annotations:
+              olm.operatorframework.io/exclude-global-namespace-resolution: "true"
           spec:
             targetNamespaces:
               - openshift-addon-operator


### PR DESCRIPTION
This adds an annotation to the OperatorGroup to allow OLM to be more resilient if a catalog source becomes in a bad state.

**References**
https://bugzilla.redhat.com/show_bug.cgi?id=2076323
https://issues.redhat.com/browse/OSD-12071