### PR TITLE
Report status on non-linked CSV

### DIFF
--- a/internal/controllers/addon/phase_ensure_subscription.go
+++ b/internal/controllers/addon/phase_ensure_subscription.go
@@ -83,7 +83,7 @@ func (r *olmReconciler) ensureSubscription(
 		// type: ResolutionFailed
 		meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
 			Type:               addonsv1alpha1.Available,
-			Status:             metav1.ConditionUnknown,
+			Status:             metav1.ConditionFalse,
 			Reason:             addonsv1alpha1.AddonReasonUnreadyCSV,
 			Message:            "CSV not linked in Subscription. Dependency issue?",
 			ObservedGeneration: addon.Generation,


### PR DESCRIPTION
Addon Operator didn't update its status at all when the CSV was not linked from the Subscription, making it harder to pinpoint the issue.

This change is now updating the Available condition and providing additional information to point in the right direction.

Signed-off-by: Nico Schieder <nschieder@redhat.com>