### PR TITLE
[MTSRE-686] Parameterize Leader Election Namespace

### DIFF
--- a/cmd/addon-operator-manager/options.go
+++ b/cmd/addon-operator-manager/options.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+)
+
+type options struct {
+	EnableLeaderElection    bool
+	EnableMetricsRecorder   bool
+	LeaderElectionNamespace string
+	MetricsAddr             string
+	Namespace               string
+	PprofAddr               string
+	ProbeAddr               string
+}
+
+// Process retrieves values from flags, environment values,
+// and secret files in order and then validates the provided
+// values to determine if any are invalid.
+func (o *options) Process() error {
+	o.parseFlags()
+	o.processEnv()
+	o.processSecrets()
+
+	o.applyValuesFromOptions()
+
+	return o.validate()
+}
+
+func (o *options) parseFlags() {
+	flag.BoolVar(
+		&o.EnableLeaderElection,
+		"enable-leader-election",
+		o.EnableLeaderElection,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.",
+	)
+
+	flag.BoolVar(
+		&o.EnableMetricsRecorder,
+		"enable-metrics-recorder",
+		o.EnableMetricsRecorder,
+		"Enable recording Addon Metrics",
+	)
+
+	flag.StringVar(
+		&o.LeaderElectionNamespace,
+		"leader-election-namspace",
+		o.LeaderElectionNamespace,
+		"The namespace in which the Leader Election resource wil be created.",
+	)
+
+	flag.StringVar(
+		&o.MetricsAddr,
+		"metrics-addr",
+		o.MetricsAddr,
+		"The address the metric endpoint binds to.",
+	)
+
+	flag.StringVar(
+		&o.Namespace,
+		"namespace",
+		o.Namespace,
+		"The namespace in which the operator is running.",
+	)
+
+	flag.StringVar(
+		&o.PprofAddr,
+		"pprof-addr", o.PprofAddr,
+		"The address the pprof web endpoint binds to.",
+	)
+
+	flag.StringVar(
+		&o.ProbeAddr,
+		"health-probe-bind-address",
+		o.ProbeAddr,
+		"The address the probe endpoint binds to.",
+	)
+
+	flag.Parse()
+}
+
+func (o *options) processEnv() {
+	if ns := os.Getenv("ADDON_OPERATOR_NAMESPACE"); ns != "" {
+		if o.Namespace == "" {
+			o.Namespace = ns
+		}
+	}
+
+	if ns := os.Getenv("ADDON_OPERATOR_LE_NAMESPACE"); ns != "" {
+		if o.LeaderElectionNamespace == "" {
+			o.LeaderElectionNamespace = ns
+		}
+	}
+}
+
+func (o *options) processSecrets() {
+	const (
+		scrtsPath              = "/var/run/secrets"
+		inClusterNamespacePath = scrtsPath + "/kubernetes.io/serviceaccount/namespace"
+	)
+
+	var namespace string
+
+	if ns, err := os.ReadFile(inClusterNamespacePath); err == nil {
+		// Avoid applying a garbage value if an error occurred
+		namespace = string(ns)
+	}
+
+	if o.Namespace == "" {
+		o.Namespace = namespace
+	}
+}
+
+func (o *options) applyValuesFromOptions() {
+	if o.LeaderElectionNamespace == "" {
+		o.LeaderElectionNamespace = o.Namespace
+	}
+}
+
+var errInvalidOption = errors.New("invalid option")
+
+func (o *options) validate() error {
+	if o.Namespace == "" {
+		return fmt.Errorf("'Namespace' must not be empty: %w", errInvalidOption)
+	}
+
+	return nil
+}

--- a/magefile.go
+++ b/magefile.go
@@ -195,7 +195,7 @@ func (Build) cmd(cmd, goos, goarch string) error {
 
 	if err := sh.RunWithV(
 		env,
-		"go", "build", "-v", "-o", bin, "./cmd/"+cmd+"/main.go",
+		"go", "build", "-v", "-o", bin, "./cmd/"+cmd,
 	); err != nil {
 		return fmt.Errorf("compiling cmd/%s: %w", cmd, err)
 	}


### PR DESCRIPTION
### Summary

- Updates magefile to build multiple files in `cmd` main packages
- Refactors the `addon-operator-manager` options
- Adds Leader Election Namespace option for `addon-operator-manager`