### PR TITLE
Improve 'out-of-cluster' run Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ run-addon-operator-manager:
 ## Run cmd/% against $KUBECONFIG.
 run-%: generate
 	go run -ldflags "-w $(LD_FLAGS)" \
-		./cmd/$*/main.go \
+		./cmd/$*/*.go \
 			-pprof-addr="127.0.0.1:8065" \
 			-metrics-addr="0"
 

--- a/README.md
+++ b/README.md
@@ -110,14 +110,17 @@ This command will:
 2. Install OLM and OpenShift Console
 
 ```shell
-# just install Addon Operator CRDs
+# Install Addon Operator CRDs
 # into the cluster.
 make setup-addon-operator-crds
 
 # Make sure we run against the new kind cluster.
 export KUBECONFIG=$PWD/.cache/integration/kubeconfig
 
-# run the operator out-of-cluster:
+# Set Addon operator namespace environment variable
+export ADDON_OPERATOR_NAMESPACE=addon-operator
+
+# Run the operator out-of-cluster:
 # Mind your `KUBECONFIG` environment variable!
 make run-addon-operator-manager
 ```


### PR DESCRIPTION
Recent refactoring moved some logic from `cmd/addon-operator-manager/main.go` into `cmd/addon-operator-manager/options.go`. This patch reflects that change in the 'out-of-cluster' (local) run Make target.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>