### PR TITLE
fix: ensure status is updated for addon instances even when reconciliation fails

### DIFF
--- a/internal/controllers/addoninstance/controller.go
+++ b/internal/controllers/addoninstance/controller.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-logr/logr"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -23,13 +22,13 @@ func NewController(c client.Client, opts ...ControllerOption) *Controller {
 
 	return &Controller{
 		cfg:    cfg,
-		client: c,
+		client: NewAddonInstanceClient(c),
 	}
 }
 
 type Controller struct {
 	cfg    ControllerConfig
-	client client.Client
+	client AddonInstanceClient
 }
 
 func (r *Controller) SetupWithManager(mgr ctrl.Manager) error {
@@ -44,38 +43,33 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		"name", req.Name,
 	)
 
-	var instance av1alpha1.AddonInstance
-	if err := c.client.Get(ctx, req.NamespacedName, &instance); err != nil {
+	instance, err := c.client.Get(ctx, req.Name, req.Namespace)
+	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	defer func() {
+		log.Info("updating status conditions")
+
+		if err := c.client.UpdateStatus(ctx, instance); err != nil {
+			log.Error(err, "updating AddonInstance status")
+		}
+	}()
+
 	log.Info("reconciling AddonInstance")
 
-	var conditions []metav1.Condition
-
 	for _, p := range c.cfg.SerialPhases {
-		res := p.Execute(ctx, phase.Request{Instance: instance})
-		if err := res.Error(); err != nil {
-			log.Error(err, "reconciliation failed")
+		res := p.Execute(ctx, phase.Request{Instance: *instance})
 
-			return ctrl.Result{}, fmt.Errorf("executing phase %q: %w", p, err)
+		for _, cond := range res.Conditions {
+			cond.ObservedGeneration = instance.Generation
+
+			apimeta.SetStatusCondition(&instance.Status.Conditions, cond)
 		}
 
-		conditions = append(conditions, res.Conditions...)
-	}
-
-	for _, cond := range conditions {
-		apimeta.SetStatusCondition(&instance.Status.Conditions, cond)
-	}
-
-	instance.Status.ObservedGeneration = instance.Generation
-
-	log.Info("updating status conditions")
-
-	if err := c.client.Status().Update(ctx, &instance); err != nil {
-		return ctrl.Result{}, fmt.Errorf(
-			"updating status for AddonInstance '%s/%s': %w", instance.Namespace, instance.Name, err,
-		)
+		if err := res.Error(); err != nil {
+			return ctrl.Result{}, fmt.Errorf("executing phase %q: %w", p, err)
+		}
 	}
 
 	log.Info("successfully reconciled AddonInstance")
@@ -112,4 +106,43 @@ type ControllerOption interface {
 type Phase interface {
 	Execute(ctx context.Context, req phase.Request) phase.Result
 	fmt.Stringer
+}
+
+type AddonInstanceClient interface {
+	Get(ctx context.Context, name, namespace string) (*av1alpha1.AddonInstance, error)
+	UpdateStatus(ctx context.Context, instance *av1alpha1.AddonInstance) error
+}
+
+func NewAddonInstanceClient(client client.Client) *AddonInstanceClientImpl {
+	return &AddonInstanceClientImpl{
+		client: client,
+	}
+}
+
+type AddonInstanceClientImpl struct {
+	client client.Client
+}
+
+func (c *AddonInstanceClientImpl) Get(ctx context.Context, name, namespace string) (*av1alpha1.AddonInstance, error) {
+	key := client.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}
+
+	instance := &av1alpha1.AddonInstance{}
+	if err := c.client.Get(ctx, key, instance); err != nil {
+		return nil, fmt.Errorf("getting AddonInstance '%s/%s': %w", namespace, name, err)
+	}
+
+	return instance, nil
+}
+
+func (c *AddonInstanceClientImpl) UpdateStatus(ctx context.Context, instance *av1alpha1.AddonInstance) error {
+	instance.Status.ObservedGeneration = instance.Generation
+
+	if err := c.client.Status().Update(ctx, instance); err != nil {
+		return fmt.Errorf("updating AddonInstance status: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Summary

Defers addon instance status updates so that it always executes even when the addon instance reconcile loop requeues on failure.