### PR TITLE
[MTSRE-773] Avoid crash on missing version

### DIFF
--- a/apis/addons/v1alpha1/addons_types.go
+++ b/apis/addons/v1alpha1/addons_types.go
@@ -72,7 +72,8 @@ type AddonUpgradePolicyStatus struct {
 	// Upgrade policy value.
 	Value AddonUpgradePolicyValue `json:"value"`
 	// Upgrade Policy Version.
-	Version string `json:"version"`
+	// +optional
+	Version string `json:"version,omitempty"`
 	// The most recent generation a status update was based on.
 	ObservedGeneration int64 `json:"observedGeneration"`
 }

--- a/config/deploy/addons.managed.openshift.io_addons.yaml
+++ b/config/deploy/addons.managed.openshift.io_addons.yaml
@@ -446,7 +446,6 @@ spec:
                 - id
                 - observedGeneration
                 - value
-                - version
                 type: object
             type: object
         type: object

--- a/config/example/addon-operator.yaml
+++ b/config/example/addon-operator.yaml
@@ -6,5 +6,5 @@ spec:
   ocm:
     endpoint: http://api-mock.api-mock.svc.cluster.local
     secret:
-      name: api-mock
+      name: pull-secret
       namespace: api-mock

--- a/config/example/reference-addon.yaml
+++ b/config/example/reference-addon.yaml
@@ -16,6 +16,7 @@ spec:
       additionalCatalogSources:
       - name: test-1
         image: quay.io/osd-addons/reference-addon-index@sha256:58cb1c4478a150dc44e6c179d709726516d84db46e4e130a5227d8b76456b5bd
+  version: 1.0.0
   upgradePolicy:
     id: 123-456-789
   monitoring:

--- a/config/openshift/manifests/addons.crd.yaml
+++ b/config/openshift/manifests/addons.crd.yaml
@@ -444,7 +444,6 @@ spec:
                 - id
                 - observedGeneration
                 - value
-                - version
                 type: object
             type: object
         type: object

--- a/docs/api-reference/_index.md
+++ b/docs/api-reference/_index.md
@@ -304,7 +304,7 @@ Tracks the last state last reported to the Upgrade Policy endpoint.
 | ----- | ----------- | ------ | -------- |
 | id | Upgrade policy id. | string | true |
 | value | Upgrade policy value. | AddonUpgradePolicyValue.addons.managed.openshift.io/v1alpha1 | true |
-| version | Upgrade Policy Version. | string | true |
+| version | Upgrade Policy Version. | string | false |
 | observedGeneration | The most recent generation a status update was based on. | int64 | true |
 
 [Back to Group]()

--- a/integration/fixtures_test.go
+++ b/integration/fixtures_test.go
@@ -60,6 +60,7 @@ func addon_OwnNamespace_UpgradePolicyReporting() *addonsv1alpha1.Addon {
 					},
 				},
 			},
+			Version: "1.0.0",
 			UpgradePolicy: &addonsv1alpha1.AddonUpgradePolicy{
 				ID: "123-456-789",
 			},

--- a/internal/controllers/addon/controller.go
+++ b/internal/controllers/addon/controller.go
@@ -126,6 +126,10 @@ type ocmClient interface {
 		ctx context.Context,
 		req ocm.UpgradePolicyPatchRequest,
 	) (res ocm.UpgradePolicyPatchResponse, err error)
+	GetUpgradePolicy(
+		ctx context.Context,
+		req ocm.UpgradePolicyGetRequest,
+	) (res ocm.UpgradePolicyGetResponse, err error)
 }
 
 func (r *AddonReconciler) InjectOCMClient(ctx context.Context, c *ocm.Client) error {

--- a/internal/controllers/addon/upgradepolicy_status_test.go
+++ b/internal/controllers/addon/upgradepolicy_status_test.go
@@ -86,12 +86,15 @@ func TestAddonReconciler_handleUpgradePolicyStatusReporting(t *testing.T) {
 			Recorder:  recorder,
 		}
 
+		var Version = "1.0.0"
+
 		log := testutil.NewLogger(t)
 		addon := &addonsv1alpha1.Addon{
 			ObjectMeta: metav1.ObjectMeta{
 				Generation: 100,
 			},
 			Spec: addonsv1alpha1.AddonSpec{
+				Version: Version,
 				UpgradePolicy: &addonsv1alpha1.AddonUpgradePolicy{
 					ID: "1234",
 				},
@@ -102,7 +105,7 @@ func TestAddonReconciler_handleUpgradePolicyStatusReporting(t *testing.T) {
 			On("PatchUpgradePolicy", mock.Anything, ocm.UpgradePolicyPatchRequest{
 				ID:          "1234",
 				Value:       ocm.UpgradePolicyValueStarted,
-				Description: `Upgrading addon to version "".`,
+				Description: `Upgrading addon to version "1.0.0".`,
 			}).
 			Return(
 				ocm.UpgradePolicyPatchResponse{},
@@ -138,19 +141,23 @@ func TestAddonReconciler_handleUpgradePolicyStatusReporting(t *testing.T) {
 		}
 		log := testutil.NewLogger(t)
 
+		var Version = "1.0.0"
+
 		err := r.handleUpgradePolicyStatusReporting(
 			context.Background(),
 			log,
 			&addonsv1alpha1.Addon{
 				Spec: addonsv1alpha1.AddonSpec{
+					Version: Version,
 					UpgradePolicy: &addonsv1alpha1.AddonUpgradePolicy{
 						ID: "1234",
 					},
 				},
 				Status: addonsv1alpha1.AddonStatus{
 					UpgradePolicy: &addonsv1alpha1.AddonUpgradePolicyStatus{
-						ID:    "1234",
-						Value: addonsv1alpha1.AddonUpgradePolicyValueStarted,
+						ID:      "1234",
+						Version: Version,
+						Value:   addonsv1alpha1.AddonUpgradePolicyValueStarted,
 					},
 				},
 			},
@@ -166,6 +173,8 @@ func TestAddonReconciler_handleUpgradePolicyStatusReporting(t *testing.T) {
 		mockSummary := testutil.NewSummaryMock()
 		recorder.InjectOCMAPIRequestDuration(mockSummary)
 
+		var Version = "1.0.0"
+
 		r := &AddonReconciler{
 			Client:    client,
 			ocmClient: ocmClient,
@@ -177,6 +186,7 @@ func TestAddonReconciler_handleUpgradePolicyStatusReporting(t *testing.T) {
 				Generation: 100,
 			},
 			Spec: addonsv1alpha1.AddonSpec{
+				Version: Version,
 				UpgradePolicy: &addonsv1alpha1.AddonUpgradePolicy{
 					ID: "1234",
 				},
@@ -189,8 +199,9 @@ func TestAddonReconciler_handleUpgradePolicyStatusReporting(t *testing.T) {
 					},
 				},
 				UpgradePolicy: &addonsv1alpha1.AddonUpgradePolicyStatus{
-					ID:    "1234",
-					Value: addonsv1alpha1.AddonUpgradePolicyValueStarted,
+					ID:      "1234",
+					Version: Version,
+					Value:   addonsv1alpha1.AddonUpgradePolicyValueStarted,
 				},
 			},
 		}
@@ -199,7 +210,7 @@ func TestAddonReconciler_handleUpgradePolicyStatusReporting(t *testing.T) {
 			On("PatchUpgradePolicy", mock.Anything, ocm.UpgradePolicyPatchRequest{
 				ID:          "1234",
 				Value:       ocm.UpgradePolicyValueCompleted,
-				Description: `Addon was healthy at least once at version "".`,
+				Description: `Addon was healthy at least once at version "1.0.0".`,
 			}).
 			Return(
 				ocm.UpgradePolicyPatchResponse{},

--- a/internal/ocm/ocmtest/mock.go
+++ b/internal/ocm/ocmtest/mock.go
@@ -25,6 +25,15 @@ func (c *Client) PatchUpgradePolicy(
 		args.Error(1)
 }
 
+func (c *Client) GetUpgradePolicy(
+	ctx context.Context,
+	req ocm.UpgradePolicyGetRequest,
+) (ocm.UpgradePolicyGetResponse, error) {
+	args := c.Called(ctx, req)
+	return args.Get(0).(ocm.UpgradePolicyGetResponse),
+		args.Error(1)
+}
+
 func (c *Client) GetCluster(
 	ctx context.Context,
 	req ocm.ClusterGetRequest,


### PR DESCRIPTION
This is a follow-up to https://github.com/openshift/addon-operator/pull/259 so we handle the current fleet.

A value for the .status.UpgradePolicy.Version is not currently present on the fleet.

This makes the .status.upgradePolicy.version optional, filling it when we have a .Spec.Version and the UpgradePolicy is "completed" in the OCM API.