### PR TITLE
[MTSRE-783] webhook replicas set to 2

### DIFF
--- a/config/olm/addon-operator.csv.tpl.yaml
+++ b/config/olm/addon-operator.csv.tpl.yaml
@@ -230,7 +230,7 @@ spec:
                   secretName: metrics-server-cert
       - name: addon-operator-webhooks
         spec:
-          replicas: 3
+          replicas: 2
           selector:
             matchLabels:
               app.kubernetes.io/name: addon-operator-webhook-server

--- a/config/openshift/manifests/addon-operator.csv.yaml
+++ b/config/openshift/manifests/addon-operator.csv.yaml
@@ -230,7 +230,7 @@ spec:
                   secretName: metrics-server-cert
       - name: addon-operator-webhooks
         spec:
-          replicas: 3
+          replicas: 2
           selector:
             matchLabels:
               app.kubernetes.io/name: addon-operator-webhook-server


### PR DESCRIPTION
Signed-off-by: Ankit Kurmi <akurmi@redhat.com>

## Description

webhook replicas set to `2` instead of `3`.