### PR TITLE
fix: ensure webhook can deploy on separate nodes for 2 infra node clusters

### DIFF
--- a/config/deploy/webhook/deployment.yaml.tpl
+++ b/config/deploy/webhook/deployment.yaml.tpl
@@ -24,16 +24,14 @@ spec:
               - key: node-role.kubernetes.io/infra
                 operator: Exists
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - addon-operator-webhook-server
-              topologyKey: "kubernetes.io/hostname"
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - addon-operator-webhook-server
+            topologyKey: "kubernetes.io/hostname"
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/infra

--- a/config/olm/addon-operator.csv.tpl.yaml
+++ b/config/olm/addon-operator.csv.tpl.yaml
@@ -229,7 +229,7 @@ spec:
                   secretName: metrics-server-cert
       - name: addon-operator-webhooks
         spec:
-          replicas: 3
+          replicas: 2
           selector:
             matchLabels:
               app.kubernetes.io/name: addon-operator-webhook-server
@@ -248,16 +248,14 @@ spec:
                       - key: node-role.kubernetes.io/infra
                         operator: Exists
                 podAntiAffinity:
-                  preferredDuringSchedulingIgnoredDuringExecution:
-                  - podAffinityTerm:
-                      labelSelector:
-                        matchExpressions:
-                        - key: app.kubernetes.io/name
-                          operator: In
-                          values:
-                          - addon-operator-webhook-server
-                      topologyKey: kubernetes.io/hostname
-                    weight: 100
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                  - labelSelector:
+                      matchExpressions:
+                      - key: app.kubernetes.io/name
+                        operator: In
+                        values:
+                        - addon-operator-webhook-server
+                    topologyKey: "kubernetes.io/hostname"
               containers:
               - image: quay.io/openshift/addon-operator-webhook:latest
                 livenessProbe:

--- a/config/openshift/manifests/addon-operator.csv.yaml
+++ b/config/openshift/manifests/addon-operator.csv.yaml
@@ -229,7 +229,7 @@ spec:
                   secretName: metrics-server-cert
       - name: addon-operator-webhooks
         spec:
-          replicas: 3
+          replicas: 2
           selector:
             matchLabels:
               app.kubernetes.io/name: addon-operator-webhook-server
@@ -248,16 +248,14 @@ spec:
                       - key: node-role.kubernetes.io/infra
                         operator: Exists
                 podAntiAffinity:
-                  preferredDuringSchedulingIgnoredDuringExecution:
-                  - podAffinityTerm:
-                      labelSelector:
-                        matchExpressions:
-                        - key: app.kubernetes.io/name
-                          operator: In
-                          values:
-                          - addon-operator-webhook-server
-                      topologyKey: kubernetes.io/hostname
-                    weight: 100
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                  - labelSelector:
+                      matchExpressions:
+                      - key: app.kubernetes.io/name
+                        operator: In
+                        values:
+                        - addon-operator-webhook-server
+                    topologyKey: kubernetes.io/hostname
               containers:
               - image: quay.io/openshift/addon-operator-webhook:latest
                 livenessProbe:


### PR DESCRIPTION
### Summary

Since requiring that the initial scheduling of manager and webhook pods places them on `infra` nodes it was observed that sequential node label caused all pods to be placed on a single node. These changes require `podAntiAffinity` for webhook nodes to prevent that. A side-effect of this is that the webhook deployment replicas must be reduced to `2` to guarantee deployment readiness on clusters with only two infra nodes.