### PR TITLE
fix: ensure webhook deployment updates allow pod eviction

### DIFF
--- a/config/deploy/webhook/deployment.yaml.tpl
+++ b/config/deploy/webhook/deployment.yaml.tpl
@@ -10,6 +10,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: addon-operator-webhook-server
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/config/olm/addon-operator.csv.tpl.yaml
+++ b/config/olm/addon-operator.csv.tpl.yaml
@@ -233,7 +233,11 @@ spec:
           selector:
             matchLabels:
               app.kubernetes.io/name: addon-operator-webhook-server
-          strategy: {}
+          strategy:
+            rollingUpdate:
+              maxSurge: 25%
+              maxUnavailable: 1
+            type: RollingUpdate
           template:
             metadata:
               creationTimestamp: null

--- a/config/openshift/manifests/addon-operator.csv.yaml
+++ b/config/openshift/manifests/addon-operator.csv.yaml
@@ -233,7 +233,11 @@ spec:
           selector:
             matchLabels:
               app.kubernetes.io/name: addon-operator-webhook-server
-          strategy: {}
+          strategy:
+            rollingUpdate:
+              maxSurge: 25%
+              maxUnavailable: 1
+            type: RollingUpdate
           template:
             metadata:
               creationTimestamp: null


### PR DESCRIPTION
### Summary

Ensures ADO can be updated successfully now that `podAntiAffinity` is required for the webhook pods.