### PR TITLE
fix: add UpgradePolicy state awareness to addon controller

### DIFF
--- a/integration/ocm_integration_test.go
+++ b/integration/ocm_integration_test.go
@@ -27,6 +27,12 @@ func (s *integrationTestSuite) TestUpgradePolicyReporting() {
 		s.addonCleanup(addon, ctx)
 	})
 
+	_, err = integration.OCMClient.PatchUpgradePolicy(ctx, ocm.UpgradePolicyPatchRequest{
+		ID:    addon.Spec.UpgradePolicy.ID,
+		Value: ocm.UpgradePolicyValueScheduled,
+	})
+	s.Require().NoError(err)
+
 	// wait until Addon is available
 	err = integration.WaitForObject(
 		s.T(), defaultAddonAvailabilityTimeout, addon, "to be Available",

--- a/internal/controllers/addon/upgradepolicy_status_test.go
+++ b/internal/controllers/addon/upgradepolicy_status_test.go
@@ -102,6 +102,16 @@ func TestAddonReconciler_handleUpgradePolicyStatusReporting(t *testing.T) {
 		}
 
 		ocmClient.
+			On("GetUpgradePolicy", mock.Anything, ocm.UpgradePolicyGetRequest{
+				ID: "1234",
+			}).
+			Return(
+				ocm.UpgradePolicyGetResponse{
+					Value: ocm.UpgradePolicyValueScheduled,
+				}, nil,
+			)
+
+		ocmClient.
 			On("PatchUpgradePolicy", mock.Anything, ocm.UpgradePolicyPatchRequest{
 				ID:          "1234",
 				Value:       ocm.UpgradePolicyValueStarted,
@@ -136,6 +146,16 @@ func TestAddonReconciler_handleUpgradePolicyStatusReporting(t *testing.T) {
 
 	t.Run("noop when upgrade started, but Addon not Available", func(t *testing.T) {
 		ocmClient := ocmtest.NewClient()
+		ocmClient.
+			On("GetUpgradePolicy", mock.Anything, ocm.UpgradePolicyGetRequest{
+				ID: "1234",
+			}).
+			Return(
+				ocm.UpgradePolicyGetResponse{
+					Value: ocm.UpgradePolicyValueStarted,
+				}, nil,
+			)
+
 		r := &AddonReconciler{
 			ocmClient: ocmClient,
 		}
@@ -206,6 +226,15 @@ func TestAddonReconciler_handleUpgradePolicyStatusReporting(t *testing.T) {
 			},
 		}
 
+		ocmClient.
+			On("GetUpgradePolicy", mock.Anything, ocm.UpgradePolicyGetRequest{
+				ID: "1234",
+			}).
+			Return(
+				ocm.UpgradePolicyGetResponse{
+					Value: ocm.UpgradePolicyValueStarted,
+				}, nil,
+			)
 		ocmClient.
 			On("PatchUpgradePolicy", mock.Anything, ocm.UpgradePolicyPatchRequest{
 				ID:          "1234",

--- a/internal/ocm/upgradepolicy.go
+++ b/internal/ocm/upgradepolicy.go
@@ -10,6 +10,9 @@ import (
 type UpgradePolicyValue string
 
 const (
+	UpgradePolicyValueNone      UpgradePolicyValue = ""
+	UpgradePolicyValuePending   UpgradePolicyValue = "pending"
+	UpgradePolicyValueScheduled UpgradePolicyValue = "scheduled"
 	UpgradePolicyValueStarted   UpgradePolicyValue = "started"
 	UpgradePolicyValueCompleted UpgradePolicyValue = "completed"
 )


### PR DESCRIPTION
### Summary

Ensure the addon controller properly handles UpgradePolicy edge cases by inspecting the previous UpgradePolicy state value.