### PR TITLE
[MTSRE-794] Monitoring Federation status reporting

### DIFF
--- a/internal/controllers/addon/monitoring_federation_reconciler_test.go
+++ b/internal/controllers/addon/monitoring_federation_reconciler_test.go
@@ -31,7 +31,7 @@ func TestEnsureMonitoringFederation_MonitoringFullyMissingInSpec_NotPresentInClu
 	}
 
 	ctx := context.Background()
-	err := r.ensureMonitoringFederation(ctx, addon)
+	_, err := r.ensureMonitoringFederation(ctx, addon)
 	require.NoError(t, err)
 	c.AssertExpectations(t)
 }
@@ -70,7 +70,7 @@ func TestEnsureMonitoringFederation_MonitoringPresentInSpec_NotPresentInCluster(
 		Return(nil)
 
 	ctx := context.Background()
-	err := r.ensureMonitoringFederation(ctx, addon)
+	_, err := r.ensureMonitoringFederation(ctx, addon)
 	require.NoError(t, err)
 	c.AssertExpectations(t)
 	c.AssertNumberOfCalls(t, "Get", 2)
@@ -152,7 +152,7 @@ func TestEnsureMonitoringFederation_MonitoringPresentInSpec_PresentInCluster(t *
 		Return(nil)
 
 	ctx := context.Background()
-	err := r.ensureMonitoringFederation(ctx, addon)
+	_, err := r.ensureMonitoringFederation(ctx, addon)
 	require.NoError(t, err)
 }
 
@@ -227,7 +227,7 @@ func TestEnsureMonitoringFederation_Adoption(t *testing.T) {
 
 			addonCopy := addon.DeepCopy()
 
-			err := rec.ensureMonitoringFederation(context.Background(), addonCopy)
+			_, err := rec.ensureMonitoringFederation(context.Background(), addonCopy)
 			assert.NoError(t, err)
 
 			c.AssertExpectations(t)


### PR DESCRIPTION
Signed-off-by: Ankit Kurmi <akurmi@redhat.com>

## Description

Currently, the way the status reporting of the monitoring_federation_reconciler is set up, it would never reach the owner Addon CR.

That's because just after the only place where monitoring_federation_reconciler reports a status, it throws a reconciler error. (Ref: https://github.com/openshift/addon-operator/blob/main/internal/controllers/addon/monitoring_federation_reconciler.go#L109-L114)

And the way the Addon control loop works, it only updates the status of the Addon CR when there's no reconciler error, otherwise it just skips the status reporting. (Ref: https://github.com/openshift/addon-operator/blob/main/internal/controllers/addon/controller.go#L233-L253)