### PR TITLE
feat: introduce addon upgrading condition

### DIFF
--- a/apis/addons/v1alpha1/addoninstances_types.go
+++ b/apis/addons/v1alpha1/addoninstances_types.go
@@ -32,15 +32,21 @@ type AddonInstanceStatus struct {
 // apiVersion: addons.managed.openshift.io/v1alpha1
 // kind: AddonInstance
 // metadata:
-//   name: addon-instance
-//   namespace: my-addon-namespace
+//
+//	name: addon-instance
+//	namespace: my-addon-namespace
+//
 // spec:
-//   heartbeatUpdatePeriod: 30s
+//
+//	heartbeatUpdatePeriod: 30s
+//
 // status:
-//   lastHeartbeatTime: 2021-10-11T08:14:50Z
-//   conditions:
-//   - type: addons.managed.openshift.io/Healthy
-//     status: "True"
+//
+//	lastHeartbeatTime: 2021-10-11T08:14:50Z
+//	conditions:
+//	- type: addons.managed.openshift.io/Healthy
+//	  status: "True"
+//
 // ```
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/apis/addons/v1alpha1/addons_types.go
+++ b/apis/addons/v1alpha1/addons_types.go
@@ -230,8 +230,11 @@ const (
 	// Addon cannot find a referenced secret to propagate
 	AddonReasonMissingSecretForPropagation = "MissingSecretForPropagation"
 
-	// Addon is being upgraded.
-	AddonReasonUpgrading = "AddonUpgrading"
+	// Addon upgrade has started.
+	AddonReasonUpgradeStarted = "AddonUpgradeStarted"
+
+	// Addon upgrade has succeeded.
+	AddonReasonUpgradeSucceeded = "AddonUpgradeSucceeded"
 )
 
 type AddonNamespace struct {
@@ -255,8 +258,11 @@ const (
 	// Paused condition indicates that the reconciliation of resources for the Addon(s) has paused
 	Paused = "Paused"
 
-	// Upgrading condition indicates that the addon is is being upgraded.
-	Upgrading = "Upgrading"
+	// UpgradeStarted condition indicates that the addon upgrade has started.
+	UpgradeStarted = "UpgradeStarted"
+
+	// UpgradeSucceeded condition indicates that the addon upgrade has succeeded.
+	UpgradeSucceeded = "UpgradeSucceeded"
 )
 
 // AddonStatus defines the observed state of Addon
@@ -298,18 +304,22 @@ const (
 // apiVersion: addons.managed.openshift.io/v1alpha1
 // kind: Addon
 // metadata:
-//   name: reference-addon
+//
+//	name: reference-addon
+//
 // spec:
-//   displayName: An amazing example addon!
-//   namespaces:
-//   - name: reference-addon
-//   install:
-//     type: OLMOwnNamespace
-//     olmOwnNamespace:
-//       namespace: reference-addon
-//       packageName: reference-addon
-//       channel: alpha
-//       catalogSourceImage: quay.io/osd-addons/reference-addon-index@sha256:58cb1c4478a150dc44e6c179d709726516d84db46e4e130a5227d8b76456b5bd
+//
+//	displayName: An amazing example addon!
+//	namespaces:
+//	- name: reference-addon
+//	install:
+//	  type: OLMOwnNamespace
+//	  olmOwnNamespace:
+//	    namespace: reference-addon
+//	    packageName: reference-addon
+//	    channel: alpha
+//	    catalogSourceImage: quay.io/osd-addons/reference-addon-index@sha256:58cb1c4478a150dc44e6c179d709726516d84db46e4e130a5227d8b76456b5bd
+//
 // ```
 //
 // +kubebuilder:object:root=true

--- a/apis/addons/v1alpha1/addons_types.go
+++ b/apis/addons/v1alpha1/addons_types.go
@@ -229,6 +229,9 @@ const (
 
 	// Addon cannot find a referenced secret to propagate
 	AddonReasonMissingSecretForPropagation = "MissingSecretForPropagation"
+
+	// Addon is being upgraded.
+	AddonReasonUpgrading = "AddonUpgrading"
 )
 
 type AddonNamespace struct {
@@ -251,6 +254,9 @@ const (
 
 	// Paused condition indicates that the reconciliation of resources for the Addon(s) has paused
 	Paused = "Paused"
+
+	// Upgrading condition indicates that the addon is is being upgraded.
+	Upgrading = "Upgrading"
 )
 
 // AddonStatus defines the observed state of Addon
@@ -269,6 +275,9 @@ type AddonStatus struct {
 	// Observed version of the Addon on the cluster, only present when .spec.version is populated.
 	// +optional
 	ObservedVersion string `json:"observedVersion,omitempty"`
+	// Name of the csv(available) that was last observed
+	// +optional
+	LastObservedAvailableCSV string `json:"lastObservedAvailableCSV,omitempty"`
 }
 
 type AddonPhase string

--- a/apis/addons/v1alpha1/addons_types.go
+++ b/apis/addons/v1alpha1/addons_types.go
@@ -281,7 +281,7 @@ type AddonStatus struct {
 	// Observed version of the Addon on the cluster, only present when .spec.version is populated.
 	// +optional
 	ObservedVersion string `json:"observedVersion,omitempty"`
-	// Name of the csv(available) that was last observed
+	// Namespaced name of the csv(available) that was last observed.
 	// +optional
 	LastObservedAvailableCSV string `json:"lastObservedAvailableCSV,omitempty"`
 }

--- a/config/deploy/addons.managed.openshift.io_addoninstances.yaml
+++ b/config/deploy/addons.managed.openshift.io_addoninstances.yaml
@@ -28,10 +28,10 @@ spec:
       openAPIV3Schema:
         description: "AddonInstance is a managed service facing interface to get configuration
           and report status back. \n **Example** ```yaml apiVersion: addons.managed.openshift.io/v1alpha1
-          kind: AddonInstance metadata:   name: addon-instance   namespace: my-addon-namespace
-          spec:   heartbeatUpdatePeriod: 30s status:   lastHeartbeatTime: 2021-10-11T08:14:50Z
-          \  conditions:   - type: addons.managed.openshift.io/Healthy     status:
-          \"True\" ```"
+          kind: AddonInstance metadata: \n \tname: addon-instance \tnamespace: my-addon-namespace
+          \n spec: \n \theartbeatUpdatePeriod: 30s \n status: \n \tlastHeartbeatTime:
+          2021-10-11T08:14:50Z \tconditions: \t- type: addons.managed.openshift.io/Healthy
+          \t  status: \"True\" \n ```"
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/deploy/addons.managed.openshift.io_addons.yaml
+++ b/config/deploy/addons.managed.openshift.io_addons.yaml
@@ -413,7 +413,7 @@ spec:
                   type: object
                 type: array
               lastObservedAvailableCSV:
-                description: Name of the csv(available) that was last observed
+                description: Namespaced name of the csv(available) that was last observed.
                 type: string
               observedGeneration:
                 description: The most recent generation observed by the controller.

--- a/config/deploy/addons.managed.openshift.io_addons.yaml
+++ b/config/deploy/addons.managed.openshift.io_addons.yaml
@@ -412,6 +412,9 @@ spec:
                   - type
                   type: object
                 type: array
+              lastObservedAvailableCSV:
+                description: Name of the csv(available) that was last observed
+                type: string
               observedGeneration:
                 description: The most recent generation observed by the controller.
                 format: int64

--- a/config/deploy/addons.managed.openshift.io_addons.yaml
+++ b/config/deploy/addons.managed.openshift.io_addons.yaml
@@ -27,12 +27,12 @@ spec:
     schema:
       openAPIV3Schema:
         description: "Addon is the Schema for the Addons API \n **Example** ```yaml
-          apiVersion: addons.managed.openshift.io/v1alpha1 kind: Addon metadata:   name:
-          reference-addon spec:   displayName: An amazing example addon!   namespaces:
-          \  - name: reference-addon   install:     type: OLMOwnNamespace     olmOwnNamespace:
-          \      namespace: reference-addon       packageName: reference-addon       channel:
-          alpha       catalogSourceImage: quay.io/osd-addons/reference-addon-index@sha256:58cb1c4478a150dc44e6c179d709726516d84db46e4e130a5227d8b76456b5bd
-          ```"
+          apiVersion: addons.managed.openshift.io/v1alpha1 kind: Addon metadata: \n
+          \tname: reference-addon \n spec: \n \tdisplayName: An amazing example addon!
+          \tnamespaces: \t- name: reference-addon \tinstall: \t  type: OLMOwnNamespace
+          \t  olmOwnNamespace: \t    namespace: reference-addon \t    packageName:
+          reference-addon \t    channel: alpha \t    catalogSourceImage: quay.io/osd-addons/reference-addon-index@sha256:58cb1c4478a150dc44e6c179d709726516d84db46e4e130a5227d8b76456b5bd
+          \n ```"
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/openshift/manifests/addons.crd.yaml
+++ b/config/openshift/manifests/addons.crd.yaml
@@ -25,12 +25,12 @@ spec:
     schema:
       openAPIV3Schema:
         description: "Addon is the Schema for the Addons API \n **Example** ```yaml
-          apiVersion: addons.managed.openshift.io/v1alpha1 kind: Addon metadata:   name:
-          reference-addon spec:   displayName: An amazing example addon!   namespaces:
-          \  - name: reference-addon   install:     type: OLMOwnNamespace     olmOwnNamespace:
-          \      namespace: reference-addon       packageName: reference-addon       channel:
-          alpha       catalogSourceImage: quay.io/osd-addons/reference-addon-index@sha256:58cb1c4478a150dc44e6c179d709726516d84db46e4e130a5227d8b76456b5bd
-          ```"
+          apiVersion: addons.managed.openshift.io/v1alpha1 kind: Addon metadata: \n
+          \tname: reference-addon \n spec: \n \tdisplayName: An amazing example addon!
+          \tnamespaces: \t- name: reference-addon \tinstall: \t  type: OLMOwnNamespace
+          \t  olmOwnNamespace: \t    namespace: reference-addon \t    packageName:
+          reference-addon \t    channel: alpha \t    catalogSourceImage: quay.io/osd-addons/reference-addon-index@sha256:58cb1c4478a150dc44e6c179d709726516d84db46e4e130a5227d8b76456b5bd
+          \n ```"
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -410,6 +410,9 @@ spec:
                   - type
                   type: object
                 type: array
+              lastObservedAvailableCSV:
+                description: Name of the csv(available) that was last observed
+                type: string
               observedGeneration:
                 description: The most recent generation observed by the controller.
                 format: int64

--- a/config/openshift/manifests/addons.crd.yaml
+++ b/config/openshift/manifests/addons.crd.yaml
@@ -411,7 +411,7 @@ spec:
                   type: object
                 type: array
               lastObservedAvailableCSV:
-                description: Name of the csv(available) that was last observed
+                description: Namespaced name of the csv(available) that was last observed.
                 type: string
               observedGeneration:
                 description: The most recent generation observed by the controller.

--- a/docs/api-reference/_index.md
+++ b/docs/api-reference/_index.md
@@ -283,6 +283,7 @@ AddonStatus defines the observed state of Addon
 | phase | DEPRECATED: This field is not part of any API contract it will go away as soon as kubectl can print conditions! Human readable status - please use .Conditions from code | AddonPhase.addons.managed.openshift.io/v1alpha1 | false |
 | upgradePolicy | Tracks last reported upgrade policy status. | *[AddonUpgradePolicyStatus.addons.managed.openshift.io/v1alpha1](#addonupgradepolicystatusaddonsmanagedopenshiftiov1alpha1) | false |
 | observedVersion | Observed version of the Addon on the cluster, only present when .spec.version is populated. | string | false |
+| lastObservedAvailableCSV | Name of the csv(available) that was last observed | string | false |
 
 [Back to Group]()
 

--- a/docs/api-reference/_index.md
+++ b/docs/api-reference/_index.md
@@ -46,15 +46,21 @@ AddonInstance is a managed service facing interface to get configuration and rep
 apiVersion: addons.managed.openshift.io/v1alpha1
 kind: AddonInstance
 metadata:
-  name: addon-instance
-  namespace: my-addon-namespace
+
+	name: addon-instance
+	namespace: my-addon-namespace
+
 spec:
-  heartbeatUpdatePeriod: 30s
+
+	heartbeatUpdatePeriod: 30s
+
 status:
-  lastHeartbeatTime: 2021-10-11T08:14:50Z
-  conditions:
-  - type: addons.managed.openshift.io/Healthy
-    status: "True"
+
+	lastHeartbeatTime: 2021-10-11T08:14:50Z
+	conditions:
+	- type: addons.managed.openshift.io/Healthy
+	  status: "True"
+
 ```
 
 | Field | Description | Scheme | Required |
@@ -287,7 +293,7 @@ AddonStatus defines the observed state of Addon
 | phase | DEPRECATED: This field is not part of any API contract it will go away as soon as kubectl can print conditions! Human readable status - please use .Conditions from code | AddonPhase.addons.managed.openshift.io/v1alpha1 | false |
 | upgradePolicy | Tracks last reported upgrade policy status. | *[AddonUpgradePolicyStatus.addons.managed.openshift.io/v1alpha1](#addonupgradepolicystatusaddonsmanagedopenshiftiov1alpha1) | false |
 | observedVersion | Observed version of the Addon on the cluster, only present when .spec.version is populated. | string | false |
-| lastObservedAvailableCSV | Name of the csv(available) that was last observed | string | false |
+| lastObservedAvailableCSV | Namespaced name of the csv(available) that was last observed. | string | false |
 
 [Back to Group]()
 

--- a/docs/api-reference/_index.md
+++ b/docs/api-reference/_index.md
@@ -154,18 +154,22 @@ Addon is the Schema for the Addons API
 apiVersion: addons.managed.openshift.io/v1alpha1
 kind: Addon
 metadata:
-  name: reference-addon
+
+	name: reference-addon
+
 spec:
-  displayName: An amazing example addon!
-  namespaces:
-  - name: reference-addon
-  install:
-    type: OLMOwnNamespace
-    olmOwnNamespace:
-      namespace: reference-addon
-      packageName: reference-addon
-      channel: alpha
-      catalogSourceImage: quay.io/osd-addons/reference-addon-index@sha256:58cb1c4478a150dc44e6c179d709726516d84db46e4e130a5227d8b76456b5bd
+
+	displayName: An amazing example addon!
+	namespaces:
+	- name: reference-addon
+	install:
+	  type: OLMOwnNamespace
+	  olmOwnNamespace:
+	    namespace: reference-addon
+	    packageName: reference-addon
+	    channel: alpha
+	    catalogSourceImage: quay.io/osd-addons/reference-addon-index@sha256:58cb1c4478a150dc44e6c179d709726516d84db46e4e130a5227d8b76456b5bd
+
 ```
 
 | Field | Description | Scheme | Required |

--- a/integration/fixtures_test.go
+++ b/integration/fixtures_test.go
@@ -19,8 +19,10 @@ var (
 	referenceAddonCatalogSourceImageWorking = "quay.io/osd-addons/reference-addon-index@sha256:58cb1c4478a150dc44e6c179d709726516d84db46e4e130a5227d8b76456b5bd"
 
 	// version v0.6.7
-	anotherReferenceAddonCatalogSourceImageWorking = "quay.io/osd-addons/reference-addon-index@sha256:5e19fa26ab71861ec8522b0e56a92c61fc84718c6a794e57db307164ce05a90f"
+	referenceAddonCatalogSourceImageWorkingv6 = "quay.io/osd-addons/reference-addon-index@sha256:5e19fa26ab71861ec8522b0e56a92c61fc84718c6a794e57db307164ce05a90f"
 
+	// version v0.5.0
+	referenceAddonCatalogSourceImageWorkingv5 = "quay.io/osd-addons/reference-addon-index@sha256:ccd0ab7962a7f185e9c0783319b649a17695442855208948363eac4acf6e0b5b"
 	// The latest bundle in this index image deploys a version of our referene-addon where InstallPlan and CSV never succeed
 	// because the deployed operator pod is deliberately broken through invalid readiness and liveness probes.
 	// Version: v0.1.3

--- a/integration/fixtures_test.go
+++ b/integration/fixtures_test.go
@@ -18,6 +18,9 @@ var (
 	// Version: v0.1.0
 	referenceAddonCatalogSourceImageWorking = "quay.io/osd-addons/reference-addon-index@sha256:58cb1c4478a150dc44e6c179d709726516d84db46e4e130a5227d8b76456b5bd"
 
+	// version v0.6.7
+	anotherReferenceAddonCatalogSourceImageWorking = "quay.io/osd-addons/reference-addon-index@sha256:5e19fa26ab71861ec8522b0e56a92c61fc84718c6a794e57db307164ce05a90f"
+
 	// The latest bundle in this index image deploys a version of our referene-addon where InstallPlan and CSV never succeed
 	// because the deployed operator pod is deliberately broken through invalid readiness and liveness probes.
 	// Version: v0.1.3
@@ -86,6 +89,36 @@ func addon_OwnNamespace() *addonsv1alpha1.Addon {
 					AddonInstallOLMCommon: addonsv1alpha1.AddonInstallOLMCommon{
 						Namespace:          "namespace-onbgdions",
 						CatalogSourceImage: referenceAddonCatalogSourceImageWorking,
+						Channel:            "alpha",
+						PackageName:        "reference-addon",
+						Config: &addonsv1alpha1.SubscriptionConfig{
+							EnvironmentVariables: referenceAddonConfigEnvObjects,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func addonWithVersion(version string, catalogSrc string) *addonsv1alpha1.Addon {
+	return &addonsv1alpha1.Addon{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "addon-oisafbo12",
+		},
+		Spec: addonsv1alpha1.AddonSpec{
+			Version:     version,
+			DisplayName: "addon-oisafbo12",
+			Namespaces: []addonsv1alpha1.AddonNamespace{
+				{Name: "namespace-onbgdions"},
+				{Name: "namespace-pioghfndb"},
+			},
+			Install: addonsv1alpha1.AddonInstallSpec{
+				Type: addonsv1alpha1.OLMOwnNamespace,
+				OLMOwnNamespace: &addonsv1alpha1.AddonInstallOLMOwnNamespace{
+					AddonInstallOLMCommon: addonsv1alpha1.AddonInstallOLMCommon{
+						Namespace:          "namespace-onbgdions",
+						CatalogSourceImage: catalogSrc,
 						Channel:            "alpha",
 						PackageName:        "reference-addon",
 						Config: &addonsv1alpha1.SubscriptionConfig{

--- a/internal/controllers/addon/controller.go
+++ b/internal/controllers/addon/controller.go
@@ -282,7 +282,7 @@ func (r *AddonReconciler) Reconcile(
 	// Check if the addon is being upgraded
 	// by comparing spec.version and status.ObservedVersion.
 	if addonIsBeingUpgraded(addon) {
-		reportAddonUpgradingConditionTrue(addon)
+		reportAddonUpgradeStarted(addon)
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controllers/addon/controller.go
+++ b/internal/controllers/addon/controller.go
@@ -249,6 +249,9 @@ func (r *AddonReconciler) Reconcile(
 		if err != nil {
 			return
 		}
+		// We report the observed version regardless of whether the addon
+		// is available or not.
+		reportObservedVersion(addon)
 		err = r.Status().Update(ctx, addon)
 	}()
 
@@ -275,6 +278,13 @@ func (r *AddonReconciler) Reconcile(
 
 	// Make sure Pause condition is removed
 	r.removeAddonPauseCondition(addon)
+
+	// Check if the addon is being upgraded
+	// by comparing spec.version and status.ObservedVersion.
+	if addonIsBeingUpgraded(addon) {
+		reportAddonUpgradingConditionTrue(addon)
+		return ctrl.Result{}, nil
+	}
 
 	// Ensure cache finalizer
 	if !controllerutil.ContainsFinalizer(addon, cacheFinalizer) {

--- a/internal/controllers/addon/olm_reconciler.go
+++ b/internal/controllers/addon/olm_reconciler.go
@@ -86,7 +86,7 @@ func (r *olmReconciler) Reconcile(ctx context.Context,
 	} else if requeueResult != resultNil {
 		return handleExit(requeueResult), nil
 	}
-	reportLastObservedAvailableCSV(addon, currentCSVKey.Name)
+	reportLastObservedAvailableCSV(addon, currentCSVKey.String())
 	return reconcile.Result{}, nil
 }
 

--- a/internal/controllers/addon/olm_reconciler.go
+++ b/internal/controllers/addon/olm_reconciler.go
@@ -86,6 +86,7 @@ func (r *olmReconciler) Reconcile(ctx context.Context,
 	} else if requeueResult != resultNil {
 		return handleExit(requeueResult), nil
 	}
+	reportLastObservedAvailableCSV(addon, currentCSVKey.Name)
 	return reconcile.Result{}, nil
 }
 

--- a/internal/controllers/addon/phase_observe_csv.go
+++ b/internal/controllers/addon/phase_observe_csv.go
@@ -22,7 +22,7 @@ func (r *olmReconciler) observeCurrentCSV(
 	// If the addon was being upgraded, we mark the upgrade as
 	// concluded.
 	if addonUpgradeConcluded(addon, csv) {
-		reportAddonUpgradingConditionFalse(addon)
+		reportAddonUpgradeSucceeded(addon)
 	}
 
 	var message string
@@ -46,7 +46,7 @@ func (r *olmReconciler) observeCurrentCSV(
 func addonUpgradeConcluded(addon *addonsv1alpha1.Addon, currentCSV *operatorsv1alpha1.ClusterServiceVersion) bool {
 	// Upgrading has concluded if a new CSV(compared to the last known available) has come up and is
 	// in the succeeded phase.
-	if addonUpgradingConditionTrue(addon) {
+	if addonUpgradeStarted(addon) {
 		return currentCSV.Name != addon.Status.LastObservedAvailableCSV &&
 			currentCSV.Status.Phase == operatorsv1alpha1.CSVPhaseSucceeded
 	}

--- a/internal/controllers/addon/phase_observe_csv.go
+++ b/internal/controllers/addon/phase_observe_csv.go
@@ -47,7 +47,7 @@ func addonUpgradeConcluded(addon *addonsv1alpha1.Addon, currentCSV *operatorsv1a
 	// Upgrading has concluded if a new CSV(compared to the last known available) has come up and is
 	// in the succeeded phase.
 	if addonUpgradeStarted(addon) {
-		return currentCSV.Name != addon.Status.LastObservedAvailableCSV &&
+		return namespacedName(currentCSV) != addon.Status.LastObservedAvailableCSV &&
 			currentCSV.Status.Phase == operatorsv1alpha1.CSVPhaseSucceeded
 	}
 	return false

--- a/internal/controllers/addon/utils.go
+++ b/internal/controllers/addon/utils.go
@@ -10,8 +10,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
@@ -179,6 +181,13 @@ func addonUpgradeStarted(addon *addonsv1alpha1.Addon) bool {
 		return upgradeStartedCond.Status == metav1.ConditionTrue
 	}
 	return false
+}
+
+func namespacedName(object client.Object) string {
+	return types.NamespacedName{
+		Name:      object.GetName(),
+		Namespace: object.GetNamespace(),
+	}.String()
 }
 
 func addonIsBeingUpgraded(addon *addonsv1alpha1.Addon) bool {


### PR DESCRIPTION
Signed-off-by: ashish <asnaraya@redhat.com>

This PR introduces upgrading condition to the operator. The upgrading condition is set to true when the controller observes that the spec.version is not equal to status.ObservedVersion. The condition then transitions to false when the controller sees a new CSV which is different from the last CSV it saw (from status.LastObservedAvailableCSV). 