### PR TITLE
fix: retry with backoff when observed CSV not found

### DIFF
--- a/internal/controllers/addon/phase_observe_csv.go
+++ b/internal/controllers/addon/phase_observe_csv.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
@@ -17,6 +18,10 @@ func (r *olmReconciler) observeCurrentCSV(
 ) (requeueResult, error) {
 	csv := &operatorsv1alpha1.ClusterServiceVersion{}
 	if err := r.uncachedClient.Get(ctx, csvKey, csv); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return resultRetry, nil
+		}
+
 		return resultNil, fmt.Errorf("getting installed CSV: %w", err)
 	}
 


### PR DESCRIPTION
### Summary

Returning errors from the reconciler generates immediate retry attempts which will continuous fail when the Observed CSV is not yet declared. This fix triggers a requeue with backoff when this scenario occurs to prevent an explosion of requeues. 