### PR TITLE
[MTSRE-853] addon-operator: fix unready namespace status reporting

### DIFF
--- a/internal/controllers/addon/namespace_reconciler_test.go
+++ b/internal/controllers/addon/namespace_reconciler_test.go
@@ -27,7 +27,7 @@ func TestEnsureWantedNamespaces_AddonWithoutNamespaces(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	err := r.ensureWantedNamespaces(ctx, testutil.NewTestAddonWithoutNamespace())
+	_, err := r.ensureWantedNamespaces(ctx, testutil.NewTestAddonWithoutNamespace())
 	require.NoError(t, err)
 	c.AssertExpectations(t)
 }
@@ -49,7 +49,7 @@ func TestEnsureWantedNamespaces_AddonWithSingleNamespace_Adoption(t *testing.T) 
 
 	ctx := context.Background()
 	addon := testutil.NewTestAddonWithSingleNamespace()
-	err := r.ensureWantedNamespaces(ctx, addon)
+	_, err := r.ensureWantedNamespaces(ctx, addon)
 	require.NoError(t, err)
 	c.AssertExpectations(t)
 	c.AssertCalled(t, "Get", testutil.IsContext, testutil.IsObjectKey, testutil.IsCoreV1NamespacePtr)
@@ -75,7 +75,7 @@ func TestEnsureWantedNamespaces_AddonWithSingleNamespace_Create(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	err := r.ensureWantedNamespaces(ctx, testutil.NewTestAddonWithSingleNamespace())
+	_, err := r.ensureWantedNamespaces(ctx, testutil.NewTestAddonWithSingleNamespace())
 	require.NoError(t, err)
 	c.AssertExpectations(t)
 	c.AssertCalled(t, "Get", testutil.IsContext, testutil.IsObjectKey, testutil.IsCoreV1NamespacePtr)
@@ -98,7 +98,7 @@ func TestEnsureWantedNamespaces_AddonWithMultipleNamespaces_Create(t *testing.T)
 	}
 
 	ctx := context.Background()
-	err := r.ensureWantedNamespaces(ctx, testutil.NewTestAddonWithMultipleNamespaces())
+	_, err := r.ensureWantedNamespaces(ctx, testutil.NewTestAddonWithMultipleNamespaces())
 	require.NoError(t, err)
 	// every namespace should have been created
 	namespaceCount := len(testutil.NewTestAddonWithMultipleNamespaces().Spec.Namespaces)
@@ -139,7 +139,7 @@ func TestEnsureWantedNamespaces_AddonWithMultipleNamespaces_SingleAdoption(t *te
 	ctx := context.Background()
 	addon := testutil.NewTestAddonWithMultipleNamespaces()
 	addonCopy := addon.DeepCopy()
-	err := r.ensureWantedNamespaces(ctx, addon)
+	_, err := r.ensureWantedNamespaces(ctx, addon)
 	require.NoError(t, err)
 	c.AssertExpectations(t)
 	c.AssertNumberOfCalls(t, "Get", len(addonCopy.Spec.Namespaces))
@@ -166,7 +166,7 @@ func TestEnsureWantedNamespaces_AddonWithMultipleNamespaces_MultipleAdoptions(t 
 	ctx := context.Background()
 	addon := testutil.NewTestAddonWithMultipleNamespaces()
 	addonCopy := addon.DeepCopy()
-	err := r.ensureWantedNamespaces(ctx, addon)
+	_, err := r.ensureWantedNamespaces(ctx, addon)
 	require.NoError(t, err)
 	c.AssertExpectations(t)
 	c.AssertNumberOfCalls(t, "Get", len(addonCopy.Spec.Namespaces))


### PR DESCRIPTION
Signed-off-by: Ankit Kurmi <akurmi@redhat.com>

## Description

Currently, the way the status reporting of the namespace_reconciler is set up, it would never reach the owner Addon CR.

That's because just after the only place where namespace_reconciler reports a unready status, it throws a nil error. (Ref: https://github.com/openshift/addon-operator/blob/main/internal/controllers/addon/namespace_reconciler.go#L130-L135)

And the way the Addon control loop works, it only updates the status of the Addon CR when there's no reconciler error, otherwise it just skips the status reporting. (Ref: https://github.com/openshift/addon-operator/blob/main/internal/controllers/addon/controller.go#L233-L253)

Acceptance criteria:

Namespace status reporting works properly and the unready status is definitely reported whenever the service monitor namespace is not active.