### PR TITLE
fix: boolean params to be properly parsed for feature flags

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -87,4 +87,4 @@ objects:
                 name: pull-secret
                 namespace: openshift-config
             feature_toggles:
-              experimental_features: ${EXPERIMENTAL_FEATURES}
+              experimental_features: ${{EXPERIMENTAL_FEATURES}}


### PR DESCRIPTION
At the present, moment, the saas-herper processes `${EXPERIMENTAL_FEATURES}` template as `"true"` or `"false"`.

What we want it to be parsed as is a boolean `true` or `false`

For that App-SRE team suggested to use double-braces to wrap the Template param.

More context here: https://redhat-internal.slack.com/archives/CCRND57FW/p1676615615524089?thread_ts=1676581395.162069&cid=CCRND57FW