### PR TITLE
chore: add dependabot config for dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: "docker"
+  directory: "/config/docker"
+  schedule:
+    interval: "daily"
+  commit-message:
+    prefix: fix
+    include: scope


### PR DESCRIPTION
### Summary

Adds dependabot automated PR's for our Dockerfiles.
