### PR TITLE
Use service-network-admin-kubeconfig

### DIFF
--- a/config/package/hcp/addon-operator-template.yaml
+++ b/config/package/hcp/addon-operator-template.yaml
@@ -86,7 +86,7 @@ spec:
       - name: kubeconfig
         secret:
           defaultMode: 420
-          secretName: admin-kubeconfig
+          secretName: service-network-admin-kubeconfig
       - name: tls
         secret:
           secretName: metrics-server-cert


### PR DESCRIPTION
Use internal network to reach the HostedClusters kube-apiserver and don't go over the external LB.