### PR TITLE
ci: bump to go1.19 in app-interface build

### DIFF
--- a/config/docker/app-interface-push-images.Dockerfile
+++ b/config/docker/app-interface-push-images.Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/podman/stable
 RUN yum install -y \
   python3-pip make ncurses git && \
   pip3 install pre-commit && \
-  curl -L --fail https://go.dev/dl/go1.18.6.linux-amd64.tar.gz > /tmp/go.tar.gz && \
+  curl -L --fail https://go.dev/dl/go1.19.7.linux-amd64.tar.gz > /tmp/go.tar.gz && \
   rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go.tar.gz
 
 ENV PATH="/usr/local/go/bin:${PATH}"


### PR DESCRIPTION
### Summary

Fixes CI build job for app-interface.