### PR TITLE
Adding metrics Service to the HS Package

### DIFF
--- a/config/package/hcp/metrics.service.yaml
+++ b/config/package/hcp/metrics.service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: addon-operator-metrics
+  namespace: addon-operator
+  labels:
+    app.kubernetes.io/name: addon-operator
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: metrics-server-cert
+    package-operator.run/phase: hosted-control-plane
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: https
+      port: 8443
+      targetPort: 8443
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: addon-operator


### PR DESCRIPTION
This fixes the deployment issue:

```
Events:
  Type     Reason       Age                    From               Message
  ----     ------       ----                   ----               -------
  Normal   Scheduled    135m                   default-scheduler  Successfully assigned ocm-staging-22jlbo2g53esrv50solj0umu68cpr2d1-achvtest/addon-operator-manager-58578985ff-pkc22 to ip-10-0-1-166.us-east-2.compute.internal
  Warning  FailedMount  44m (x8 over 116m)     kubelet            Unable to attach or mount volumes: unmounted volumes=[tls], unattached volumes=[kubeconfig tls kube-api-access-mxr2m]: timed out waiting for the condition
  Warning  FailedMount  24m (x18 over 133m)    kubelet            Unable to attach or mount volumes: unmounted volumes=[tls], unattached volumes=[kube-api-access-mxr2m kubeconfig tls]: timed out waiting for the condition
  Warning  FailedMount  9m58s (x34 over 131m)  kubelet            Unable to attach or mount volumes: unmounted volumes=[tls], unattached volumes=[tls kube-api-access-mxr2m kubeconfig]: timed out waiting for the condition
  Warning  FailedMount  5m (x72 over 135m)     kubelet            MountVolume.SetUp failed for volume "tls" : secret "metrics-server-cert" not found
```