### PR TITLE
Allow existing non-controlling namespace owners to remain

### DIFF
--- a/internal/controllers/addon/namespace_reconciler.go
+++ b/internal/controllers/addon/namespace_reconciler.go
@@ -171,6 +171,15 @@ func reconcileNamespace(ctx context.Context, c client.Client, namespace *corev1.
 		return nil, err
 	}
 
+	if currentNamespace.OwnerReferences != nil {
+		// Allow existing non-controlling owners to remain
+		for _, owner := range currentNamespace.OwnerReferences {
+			if owner.Controller == nil || !*owner.Controller {
+				namespace.OwnerReferences = append(namespace.OwnerReferences, owner)
+			}
+		}
+	}
+
 	currentNamespace.OwnerReferences = namespace.OwnerReferences
 
 	currentLabels := labels.Set(currentNamespace.Labels)


### PR DESCRIPTION
This change allows for an Addon namespace to have additional owners as long as they are not controllers.

The use case that this supports is a case where the addon deploys an operator working with a CR that requires clean-up/finalization. Immediately removing the operator's namespace when the addon is uninstalled prevents finalizers from running and potentially results in stuck terminating namespaces for CRs with finalizers.

To avoid the stuck finalizer situation, an Addon-aware operator may make its CRs non-controlling owners of the operator namespace as well as owned resources of the Addon. Removal of the Addon marks the CR as deleted, but blocks the namespace removal until the operator's cleanup processing removes the CR's finalizer(s).

```mermaid
erDiagram
    AddonCR   ||--|{ OperatorNS : controls
    AddonCR   ||--o{ ProductCR : owns
    ProductCR }o--|{ OperatorNS: owns
    ProductCR {
      string[] finalizers
    }
```

There may be other things to consider to support such a situation, but some initial testing with this change seems to work.