### PR TITLE
Remove namespace from metrics Service

### DIFF
--- a/config/package/hcp/metrics.service.yaml
+++ b/config/package/hcp/metrics.service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: addon-operator-metrics
-  namespace: addon-operator
   labels:
     app.kubernetes.io/name: addon-operator
   annotations:


### PR DESCRIPTION
The namespace deafults to where the Package is created