### PR TITLE
Add configuration sources to Package Operator reconciler

### DIFF
--- a/integration/pko_test.go
+++ b/integration/pko_test.go
@@ -25,11 +25,13 @@ import (
 const (
 	addonName              = "addonname-pko-boatboat"
 	addonNamespace         = "namespace-onbgdions"
-	pkoImageOptionalParams = "quay.io/alcosta/package-operator-packages/openshift/addon-operator/apnp-test-optional-params:v1.0"
-	pkoImageRequiredParams = "quay.io/alcosta/package-operator-packages/openshift/addon-operator/apnp-test-required-params:v1.0"
-	pkoDeploymentNamespace = "default"
 	deadMansSnitchUrlValue = "https://example.com/test-snitch-url"
 	pagerDutyKeyValue      = "1234567890ABCDEF"
+
+	// source: https://github.com/kostola/package-operator-packages/tree/v1.0/openshift/addon-operator/apnp-test-optional-params
+	pkoImageOptionalParams = "quay.io/alcosta/package-operator-packages/openshift/addon-operator/apnp-test-optional-params:v1.0"
+	// source: https://github.com/kostola/package-operator-packages/tree/v1.0/openshift/addon-operator/apnp-test-required-params
+	pkoImageRequiredParams = "quay.io/alcosta/package-operator-packages/openshift/addon-operator/apnp-test-required-params:v1.0"
 )
 
 func (s *integrationTestSuite) TestPackageOperatorAddon() {

--- a/integration/pko_test.go
+++ b/integration/pko_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -177,7 +178,7 @@ func (s *integrationTestSuite) waitForClusterPackage(ctx context.Context, addonN
 ) {
 	cp := &v1alpha1.ClusterPackage{ObjectMeta: metav1.ObjectMeta{Name: addonName}}
 	err := integration.WaitForObject(ctx, s.T(),
-		defaultAddonAvailabilityTimeout, cp, "to be available",
+		defaultAddonAvailabilityTimeout, cp, "to be "+conditionType,
 		clusterPackageChecker(conditionType, deadMansSnitchUrlValuePresent, pagerDutyValuePresent))
 	s.Require().NoError(err)
 }
@@ -209,14 +210,14 @@ func clusterPackageChecker(conditionType string, deadMansSnitchUrlValuePresent b
 		deadMansSnitchUrlValueOk, pagerDutyValueOk := false, false
 		if deadMansSnitchUrlValuePresent {
 			value, present := addonsv1[addon.DeadMansSnitchUrlConfigKey]
-			deadMansSnitchUrlValueOk = present && value == deadMansSnitchUrlValue
+			deadMansSnitchUrlValueOk = present && value == base64.StdEncoding.EncodeToString([]byte(deadMansSnitchUrlValue))
 		} else {
 			_, present := addonsv1[addon.DeadMansSnitchUrlConfigKey]
 			deadMansSnitchUrlValueOk = !present
 		}
 		if pagerDutyValuePresent {
 			value, present := addonsv1[addon.PagerDutyKeyConfigKey]
-			pagerDutyValueOk = present && value == pagerDutyKeyValue
+			pagerDutyValueOk = present && value == base64.StdEncoding.EncodeToString([]byte(pagerDutyKeyValue))
 		} else {
 			_, present := addonsv1[addon.PagerDutyKeyConfigKey]
 			pagerDutyValueOk = !present

--- a/integration/pko_test.go
+++ b/integration/pko_test.go
@@ -3,6 +3,9 @@ package integration_test
 import (
 	"context"
 
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/openshift/addon-operator/internal/featuretoggle"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,8 +13,14 @@ import (
 
 	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
 	"github.com/openshift/addon-operator/integration"
+)
 
-	pkov1alpha1 "package-operator.run/apis/core/v1alpha1"
+const (
+	addonName              = "addonname-pko-boatboat"
+	addonNamespace         = "namespace-onbgdions"
+	pkoImage               = "quay.io/alcosta/package-operator-packages/openshift/addon-operator/apnp-test-optional-params:v1.0"
+	deadMansSnitchUrlValue = "https://example.com/test-snitch-url"
+	pagerDutyKeyValue      = "1234567890ABCDEF"
 )
 
 func (s *integrationTestSuite) TestPackageOperatorAddon() {
@@ -21,22 +30,19 @@ func (s *integrationTestSuite) TestPackageOperatorAddon() {
 
 	ctx := context.Background()
 
-	name := "addonname-pko-boatboat"
-	image := "testimage"
-	namespace := "namespace-onbgdions"
-
+	// Addon resource
 	addon := &addonsv1alpha1.Addon{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		ObjectMeta: metav1.ObjectMeta{Name: addonName},
 		Spec: addonsv1alpha1.AddonSpec{
 			Version:              "1.0",
-			DisplayName:          name,
-			AddonPackageOperator: &addonsv1alpha1.AddonPackageOperator{Image: image},
-			Namespaces:           []addonsv1alpha1.AddonNamespace{{Name: namespace}},
+			DisplayName:          addonName,
+			AddonPackageOperator: &addonsv1alpha1.AddonPackageOperator{Image: pkoImage},
+			Namespaces:           []addonsv1alpha1.AddonNamespace{{Name: addonNamespace}},
 			Install: addonsv1alpha1.AddonInstallSpec{
 				Type: addonsv1alpha1.OLMOwnNamespace,
 				OLMOwnNamespace: &addonsv1alpha1.AddonInstallOLMOwnNamespace{
 					AddonInstallOLMCommon: addonsv1alpha1.AddonInstallOLMCommon{
-						Namespace:          namespace,
+						Namespace:          addonNamespace,
 						CatalogSourceImage: referenceAddonCatalogSourceImageWorking,
 						Channel:            "alpha",
 						PackageName:        "reference-addon",
@@ -47,18 +53,60 @@ func (s *integrationTestSuite) TestPackageOperatorAddon() {
 		},
 	}
 
-	tmpl := &pkov1alpha1.ClusterObjectTemplate{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	// Secret resources for Dead Man's Snitch and PagerDuty, simulating the structure defined in the docs. See:
+	// - https://mt-sre.github.io/docs/creating-addons/monitoring/deadmanssnitch_integration/#generated-secret
+	// - https://mt-sre.github.io/docs/creating-addons/monitoring/pagerduty_integration/
+	dmsSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: addonName + "-deadmanssnitch", Namespace: addonNamespace},
+		Data:       map[string][]byte{"SNITCH_URL": []byte(deadMansSnitchUrlValue)},
+	}
+	pdSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: addonName + "-pagerduty", Namespace: addonNamespace},
+		Data:       map[string][]byte{"PAGERDUTY_KEY": []byte(pagerDutyKeyValue)},
+	}
 
+	// create the Addon resource
 	err := integration.Client.Create(ctx, addon)
 	s.Require().NoError(err)
-	// wait until Addon is available
+
+	// wait for the Addon addonNamespace to exist (needed to publish secrets)
 	err = integration.WaitForObject(ctx, s.T(),
-		defaultAddonAvailabilityTimeout, tmpl, "to be created",
-		func(obj client.Object) (done bool, err error) {
-			_ = obj.(*pkov1alpha1.ClusterObjectTemplate)
-			return true, nil
-		})
+		defaultAddonAvailabilityTimeout, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: addonNamespace}}, "to be created",
+		func(obj client.Object) (done bool, err error) { return true, nil })
+	s.Require().NoError(err)
+
+	// create Secrets
+	err = integration.Client.Create(ctx, dmsSecret)
+	s.Require().NoError(err)
+	err = integration.Client.Create(ctx, pdSecret)
+	s.Require().NoError(err)
+
+	// wait until all the replicas in the Deployment inside the ClusterPackage are ready
+	// and check if their env variables corresponds to the secrets
+	dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: addonName, Namespace: "apnp-test-optional-params"}}
+	err = integration.WaitForObject(ctx, s.T(),
+		defaultAddonAvailabilityTimeout, dep, "to have all replicas ready",
+		validateDeployment)
 	s.Require().NoError(err)
 
 	s.T().Cleanup(func() { s.addonCleanup(addon, ctx) })
+}
+
+func validateDeployment(obj client.Object) (done bool, err error) {
+	deployment := obj.(*appsv1.Deployment)
+
+	if *deployment.Spec.Replicas != deployment.Status.ReadyReplicas {
+		return false, nil
+	}
+
+	deadMansSnitchOk, pagerDutyOk := false, false
+	for _, envItem := range deployment.Spec.Template.Spec.Containers[0].Env {
+		if envItem.Name == "MY_SNITCH_URL" {
+			deadMansSnitchOk = deadMansSnitchUrlValue == envItem.Value
+		} else if envItem.Name == "MY_PAGERDUTY_KEY" {
+			pagerDutyOk = pagerDutyKeyValue == envItem.Value
+		}
+	}
+
+	return deadMansSnitchOk && pagerDutyOk, nil
 }

--- a/internal/controllers/addon/package_operator_reconciler.go
+++ b/internal/controllers/addon/package_operator_reconciler.go
@@ -26,14 +26,21 @@ spec:
   image: "%s"
   config:
     addons:
-      v1alpha1:
-        deadMansSnitchUrl: {{.config%s | b64dec}}
-        pagerDutyKey: {{.config%s | b64dec}}
+      v1alpha1: {
+{{ with index .config "%s" -}}
+        deadMansSnitchUrl: {{ . | b64dec }}
+{{ end -}}
+{{ with index .config "%s" -}}
+        pagerDutyKey: {{ . | b64dec }}
+{{ end -}}
+      }
 `
 
-const packageOperatorName = "packageOperatorReconciler"
-const deadMansSnitchUrlConfigKey = ".deadMansSnitchUrl"
-const pagerDutyKeyConfigKey = ".pagerDutyKey"
+const (
+	packageOperatorName        = "packageOperatorReconciler"
+	deadMansSnitchUrlConfigKey = ".deadMansSnitchUrl"
+	pagerDutyKeyConfigKey      = ".pagerDutyKey"
+)
 
 type PackageOperatorReconciler struct {
 	Client client.Client

--- a/internal/controllers/addon/package_operator_reconciler.go
+++ b/internal/controllers/addon/package_operator_reconciler.go
@@ -24,7 +24,11 @@ metadata:
   namespace: "%s"
 spec:
   image: "%s"
-  config: {{toJSON .sources}}
+  config:
+    addons:
+      v1alpha1:
+        deadManSnitchUrl: {{.config.deadManSnitchUrl}}
+        pagerDutyKey: {{.config.pagerDutyKey}}
 `
 const packageOperatorName = "packageOperatorReconciler"
 
@@ -55,7 +59,34 @@ func (r *PackageOperatorReconciler) makeSureClusterObjectTemplateExists(ctx cont
 				addon.Namespace,
 				addon.Spec.AddonPackageOperator.Image,
 			),
-			Sources: []pkov1alpha1.ObjectTemplateSource{},
+			Sources: []pkov1alpha1.ObjectTemplateSource{
+				{
+					Optional:   true,
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       addon.Name + "-deadmanssnitch",
+					Namespace:  addon.Namespace,
+					Items: []pkov1alpha1.ObjectTemplateSourceItem{
+						{
+							Key:         ".data.SNITCH_URL",
+							Destination: ".deadMansSnitchUrl",
+						},
+					},
+				},
+				{
+					Optional:   true,
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       addon.Name + "-pagerduty",
+					Namespace:  addon.Namespace,
+					Items: []pkov1alpha1.ObjectTemplateSourceItem{
+						{
+							Key:         ".data.PAGERDUTY_KEY",
+							Destination: ".pagerDutyKey",
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/internal/controllers/addon/package_operator_reconciler.go
+++ b/internal/controllers/addon/package_operator_reconciler.go
@@ -40,8 +40,8 @@ spec:
 
 const (
 	packageOperatorName        = "packageOperatorReconciler"
-	deadMansSnitchUrlConfigKey = "deadMansSnitchUrl"
-	pagerDutyKeyConfigKey      = "pagerDutyKey"
+	DeadMansSnitchUrlConfigKey = "deadMansSnitchUrl"
+	PagerDutyKeyConfigKey      = "pagerDutyKey"
 )
 
 type PackageOperatorReconciler struct {
@@ -69,10 +69,10 @@ func (r *PackageOperatorReconciler) makeSureClusterObjectTemplateExists(ctx cont
 		pkov1alpha1.GroupVersion,
 		addon.Name,
 		addon.Spec.AddonPackageOperator.Image,
-		deadMansSnitchUrlConfigKey,
-		pagerDutyKeyConfigKey,
-		deadMansSnitchUrlConfigKey,
-		pagerDutyKeyConfigKey,
+		DeadMansSnitchUrlConfigKey,
+		PagerDutyKeyConfigKey,
+		DeadMansSnitchUrlConfigKey,
+		PagerDutyKeyConfigKey,
 	)
 
 	pkg := &pkov1alpha1.ClusterObjectTemplate{
@@ -91,7 +91,7 @@ func (r *PackageOperatorReconciler) makeSureClusterObjectTemplateExists(ctx cont
 					Items: []pkov1alpha1.ObjectTemplateSourceItem{
 						{
 							Key:         ".data.SNITCH_URL",
-							Destination: "." + deadMansSnitchUrlConfigKey,
+							Destination: "." + DeadMansSnitchUrlConfigKey,
 						},
 					},
 				},
@@ -104,7 +104,7 @@ func (r *PackageOperatorReconciler) makeSureClusterObjectTemplateExists(ctx cont
 					Items: []pkov1alpha1.ObjectTemplateSourceItem{
 						{
 							Key:         ".data.PAGERDUTY_KEY",
-							Destination: "." + pagerDutyKeyConfigKey,
+							Destination: "." + PagerDutyKeyConfigKey,
 						},
 					},
 				},

--- a/internal/controllers/addon/package_operator_reconciler.go
+++ b/internal/controllers/addon/package_operator_reconciler.go
@@ -56,18 +56,20 @@ func (r *PackageOperatorReconciler) makeSureClusterObjectTemplateExists(ctx cont
 
 	addonDestNamespace := addon.Spec.Namespaces[0].Name
 
+	templateString := fmt.Sprintf(pkgTemplate,
+		pkov1alpha1.GroupVersion,
+		addon.Name,
+		addon.Spec.AddonPackageOperator.Image,
+		deadMansSnitchUrlConfigKey,
+		pagerDutyKeyConfigKey,
+	)
+
 	pkg := &pkov1alpha1.ClusterObjectTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: addon.Name,
 		},
 		Spec: pkov1alpha1.ObjectTemplateSpec{
-			Template: fmt.Sprintf(pkgTemplate,
-				pkov1alpha1.GroupVersion,
-				addon.Name,
-				addon.Spec.AddonPackageOperator.Image,
-				deadMansSnitchUrlConfigKey,
-				pagerDutyKeyConfigKey,
-			),
+			Template: templateString,
 			Sources: []pkov1alpha1.ObjectTemplateSource{
 				{
 					Optional:   true,

--- a/internal/controllers/addon/package_operator_reconciler_test.go
+++ b/internal/controllers/addon/package_operator_reconciler_test.go
@@ -23,8 +23,11 @@ import (
 var (
 	addonWithoutPKO = testutil.NewTestAddonWithSingleNamespace()
 	addonWithPKO    = &addonsv1alpha1.Addon{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-addon", Namespace: "test-ns"},
-		Spec:       addonsv1alpha1.AddonSpec{AddonPackageOperator: &v1alpha1.AddonPackageOperator{Image: "test-pko-img"}},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-addon"},
+		Spec: addonsv1alpha1.AddonSpec{
+			Namespaces:           []addonsv1alpha1.AddonNamespace{{Name: "test-ns"}},
+			AddonPackageOperator: &v1alpha1.AddonPackageOperator{Image: "test-pko-img"},
+		},
 	}
 )
 

--- a/internal/controllers/addon/package_operator_reconciler_test.go
+++ b/internal/controllers/addon/package_operator_reconciler_test.go
@@ -25,7 +25,14 @@ var (
 	addonWithPKO    = &addonsv1alpha1.Addon{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-addon"},
 		Spec: addonsv1alpha1.AddonSpec{
-			Namespaces:           []addonsv1alpha1.AddonNamespace{{Name: "test-ns"}},
+			Install: addonsv1alpha1.AddonInstallSpec{
+				Type: addonsv1alpha1.OLMOwnNamespace,
+				OLMOwnNamespace: &addonsv1alpha1.AddonInstallOLMOwnNamespace{
+					AddonInstallOLMCommon: addonsv1alpha1.AddonInstallOLMCommon{
+						Namespace: "test-ns",
+					},
+				},
+			},
 			AddonPackageOperator: &v1alpha1.AddonPackageOperator{Image: "test-pko-img"},
 		},
 	}

--- a/internal/featuretoggle/addons_plug_and_play_feature_toggle.go
+++ b/internal/featuretoggle/addons_plug_and_play_feature_toggle.go
@@ -13,6 +13,8 @@ import (
 	addoncontroller "github.com/openshift/addon-operator/internal/controllers/addon"
 )
 
+const AddonsPlugAndPlayFeatureToggleIdentifier = "ADDONS_PLUG_AND_PLAY"
+
 var _ FeatureToggleHandler = (*AddonsPlugAndPlayFeatureToggle)(nil)
 
 type AddonsPlugAndPlayFeatureToggle struct {
@@ -27,7 +29,7 @@ func (h *AddonsPlugAndPlayFeatureToggle) Name() string {
 }
 
 func (h *AddonsPlugAndPlayFeatureToggle) GetFeatureToggleIdentifier() string {
-	return "ADDONS_PLUG_AND_PLAY"
+	return AddonsPlugAndPlayFeatureToggleIdentifier
 }
 
 func (h *AddonsPlugAndPlayFeatureToggle) PreManagerSetupHandle(ctx context.Context) error {

--- a/internal/featuretoggle/addons_plug_and_play_feature_toggle_testable.go
+++ b/internal/featuretoggle/addons_plug_and_play_feature_toggle_testable.go
@@ -17,7 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var pkoVersion = "1.4.0"
+var pkoVersion = "1.5.0"
 
 func (h *AddonsPlugAndPlayFeatureToggle) Enable(ctx context.Context) error {
 	adoInCluster := addonsv1alpha1.AddonOperator{}

--- a/internal/featuretoggle/addons_plug_and_play_feature_toggle_testable.go
+++ b/internal/featuretoggle/addons_plug_and_play_feature_toggle_testable.go
@@ -17,7 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var pkoVersion = "1.5.0"
+var pkoVersion = "1.6.0"
 
 func (h *AddonsPlugAndPlayFeatureToggle) Enable(ctx context.Context) error {
 	adoInCluster := addonsv1alpha1.AddonOperator{}

--- a/magefile.go
+++ b/magefile.go
@@ -710,9 +710,6 @@ func (t Test) IntegrationCIPrepare(ctx context.Context) error {
 	if err := postClusterCreationFeatureToggleSetup(ctx, cluster); err != nil {
 		return fmt.Errorf("failed to perform post-cluster creation setup for the feature toggles: %w", err)
 	}
-	if err := deployFeatureToggles(ctx, cluster); err != nil {
-		return fmt.Errorf("failed to deploy feature toggles: %w", err)
-	}
 	return nil
 }
 
@@ -868,6 +865,12 @@ func (t Test) IntegrationCI(ctx context.Context) error {
 
 	os.Setenv("ENABLE_WEBHOOK", "true")
 	os.Setenv("ENABLE_API_MOCK", "true")
+
+	// force ADDONS_PLUG_AND_PLAY feature toggle in CI to make sure tests are executed
+	os.Setenv("FEATURE_TOGGLES", featuretoggle.AddonsPlugAndPlayFeatureToggleIdentifier)
+	if err := deployFeatureToggles(ctx, cluster); err != nil {
+		return fmt.Errorf("failed to deploy feature toggles: %w", err)
+	}
 
 	ctx = context.WithValue(ctx, "workDir", workDir)
 	return t.Integration(ctx)

--- a/magefile.go
+++ b/magefile.go
@@ -704,8 +704,14 @@ func (t Test) IntegrationCIPrepare(ctx context.Context) error {
 	if err := labelNodesWithInfraRole(ctx, cluster); err != nil {
 		return fmt.Errorf("failed to label the nodes with infra role: %w", err)
 	}
+
+	// force ADDONS_PLUG_AND_PLAY feature toggle in CI to make sure tests are executed
+	os.Setenv("FEATURE_TOGGLES", featuretoggle.AddonsPlugAndPlayFeatureToggleIdentifier)
 	if err := postClusterCreationFeatureToggleSetup(ctx, cluster); err != nil {
-		return err
+		return fmt.Errorf("failed to perform post-cluster creation setup for the feature toggles: %w", err)
+	}
+	if err := deployFeatureToggles(ctx, cluster); err != nil {
+		return fmt.Errorf("failed to deploy feature toggles: %w", err)
 	}
 	return nil
 }

--- a/magefile.go
+++ b/magefile.go
@@ -681,6 +681,8 @@ func (Test) Integration(ctx context.Context) error {
 		return fmt.Errorf("creating cluster client: %w", err)
 	}
 
+	// force ADDONS_PLUG_AND_PLAY feature toggle in CI to make sure tests are executed
+	os.Setenv("FEATURE_TOGGLES", featuretoggle.AddonsPlugAndPlayFeatureToggleIdentifier)
 	if err := postClusterCreationFeatureToggleSetup(ctx, cluster); err != nil {
 		return fmt.Errorf("failed to perform post-cluster creation setup for the feature toggles: %w", err)
 	}
@@ -703,12 +705,6 @@ func (t Test) IntegrationCIPrepare(ctx context.Context) error {
 	ctx = logr.NewContext(ctx, logger)
 	if err := labelNodesWithInfraRole(ctx, cluster); err != nil {
 		return fmt.Errorf("failed to label the nodes with infra role: %w", err)
-	}
-
-	// force ADDONS_PLUG_AND_PLAY feature toggle in CI to make sure tests are executed
-	os.Setenv("FEATURE_TOGGLES", featuretoggle.AddonsPlugAndPlayFeatureToggleIdentifier)
-	if err := postClusterCreationFeatureToggleSetup(ctx, cluster); err != nil {
-		return fmt.Errorf("failed to perform post-cluster creation setup for the feature toggles: %w", err)
 	}
 	return nil
 }
@@ -865,12 +861,6 @@ func (t Test) IntegrationCI(ctx context.Context) error {
 
 	os.Setenv("ENABLE_WEBHOOK", "true")
 	os.Setenv("ENABLE_API_MOCK", "true")
-
-	// force ADDONS_PLUG_AND_PLAY feature toggle in CI to make sure tests are executed
-	os.Setenv("FEATURE_TOGGLES", featuretoggle.AddonsPlugAndPlayFeatureToggleIdentifier)
-	if err := deployFeatureToggles(ctx, cluster); err != nil {
-		return fmt.Errorf("failed to deploy feature toggles: %w", err)
-	}
 
 	ctx = context.WithValue(ctx, "workDir", workDir)
 	return t.Integration(ctx)


### PR DESCRIPTION
Add the following sources to the Package Operator reconciler:
* Dead Man's Snitch URL
* PagerDuty API key

This first version assumes the following:
1. The configuration schema of the templated `ClusterPackage` is this ([example package](https://github.com/kostola/package-operator-packages/blob/v1.0/openshift/addon-operator/apnp-test-optional-params/manifest.yaml#L24-L37)):
```yaml
config:
  openAPIV3Schema:
    type: object
    properties:
      addonsv1:
        type: object
        description: "contains configuration passed by Addon Operator"
        properties:
          deadMansSnitchUrl:
            type: string
            description: "Dead Man's Snitch URL"
          pagerDutyKey:
            type: string
            description: "PagerDuty API key"
```
3. The Dead Man's Snitch URL is in a secret named `<addon_name>-deadmanssnitch` in the same namespace where the addon is going to be deployed (as specified [here](https://mt-sre.github.io/docs/creating-addons/monitoring/deadmanssnitch_integration/#generated-secret)).
4. The PagerDuty API key is in a secret named `<addon_name>-pagerduty` in the same namespace where the addon is going to be deployed (as specified [here](https://mt-sre.github.io/docs/creating-addons/monitoring/pagerduty_integration/)).