### PR TITLE
Mount user provided CA bundle to the container

### DIFF
--- a/config/deploy/deployment.yaml.tpl
+++ b/config/deploy/deployment.yaml.tpl
@@ -53,9 +53,6 @@ spec:
         - name: tls
           mountPath: "/tmp/k8s-metrics-server/serving-certs/"
           readOnly: true
-        - mountPath: /etc/pki/ca-trust/extracted/pem
-          name: trusted-ca-bundle
-          readOnly: true
         ports:
         - containerPort: 8443
         readinessProbe:
@@ -79,6 +76,10 @@ spec:
         image: quay.io/openshift/addon-operator:latest
         args:
         - --enable-leader-election
+        volumeMounts:
+        - mountPath: /etc/pki/ca-trust/extracted/pem
+          name: trusted-ca-bundle
+          readOnly: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/deploy/deployment.yaml.tpl
+++ b/config/deploy/deployment.yaml.tpl
@@ -30,6 +30,14 @@ spec:
       - name: tls
         secret:
           secretName: metrics-server-cert
+      - configMap:
+          defaultMode: 420
+          items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
+          name: trusted-ca-bundle
+          optional: true
+        name: trusted-ca-bundle
       containers:
       - name: metrics-relay-server
         image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
@@ -44,6 +52,9 @@ spec:
         volumeMounts:
         - name: tls
           mountPath: "/tmp/k8s-metrics-server/serving-certs/"
+          readOnly: true
+        - mountPath: /etc/pki/ca-trust/extracted/pem
+          name: trusted-ca-bundle
           readOnly: true
         ports:
         - containerPort: 8443

--- a/config/deploy/trusted_ca_bundle_configmap.yaml
+++ b/config/deploy/trusted_ca_bundle_configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-managed-upgrade-operator
+  name: trusted-ca-bundle
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/config/deploy/trusted_ca_bundle_configmap.yaml
+++ b/config/deploy/trusted_ca_bundle_configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: openshift-managed-upgrade-operator
+  namespace: addon-operator
   name: trusted-ca-bundle
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"

--- a/config/olm/addon-operator.csv.tpl.yaml
+++ b/config/olm/addon-operator.csv.tpl.yaml
@@ -272,6 +272,7 @@ spec:
                       path: tls-ca-bundle.pem
                   name: trusted-ca-bundle
                   optional: true
+                name: trusted-ca-bundle
       - name: addon-operator-webhooks
         spec:
           replicas: 2

--- a/config/olm/addon-operator.csv.tpl.yaml
+++ b/config/olm/addon-operator.csv.tpl.yaml
@@ -253,6 +253,10 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 300Mi
+                volumeMounts:
+                - mountPath: /etc/pki/ca-trust/extracted/pem
+                  name: trusted-ca-bundle
+                  readOnly: true
               serviceAccountName: addon-operator
               tolerations:
               - effect: NoSchedule
@@ -261,6 +265,13 @@ spec:
               - name: tls
                 secret:
                   secretName: metrics-server-cert
+              - configMap:
+                  defaultMode: 420
+                  items:
+                    - key: ca-bundle.crt
+                      path: tls-ca-bundle.pem
+                  name: trusted-ca-bundle
+                  optional: true
       - name: addon-operator-webhooks
         spec:
           replicas: 2

--- a/config/olm/trusted_ca_bundle_configmap.yaml
+++ b/config/olm/trusted_ca_bundle_configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca-bundle
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/config/openshift/manifests/addon-operator.csv.yaml
+++ b/config/openshift/manifests/addon-operator.csv.yaml
@@ -272,7 +272,7 @@ spec:
                     path: tls-ca-bundle.pem
                   name: trusted-ca-bundle
                   optional: true
-                name: ""
+                name: trusted-ca-bundle
       - name: addon-operator-webhooks
         spec:
           replicas: 2

--- a/config/openshift/manifests/addon-operator.csv.yaml
+++ b/config/openshift/manifests/addon-operator.csv.yaml
@@ -253,6 +253,10 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 300Mi
+                volumeMounts:
+                - mountPath: /etc/pki/ca-trust/extracted/pem
+                  name: trusted-ca-bundle
+                  readOnly: true
               serviceAccountName: addon-operator
               tolerations:
               - effect: NoSchedule
@@ -261,6 +265,14 @@ spec:
               - name: tls
                 secret:
                   secretName: metrics-server-cert
+              - configMap:
+                  defaultMode: 420
+                  items:
+                  - key: ca-bundle.crt
+                    path: tls-ca-bundle.pem
+                  name: trusted-ca-bundle
+                  optional: true
+                name: ""
       - name: addon-operator-webhooks
         spec:
           replicas: 2

--- a/magefile.go
+++ b/magefile.go
@@ -1325,6 +1325,7 @@ func (d Dev) deployAddonOperatorManager(ctx context.Context, cluster *dev.Cluste
 		"config/deploy/addons.managed.openshift.io_addons.yaml",
 		"config/deploy/metrics.service.yaml",
 		"config/deploy/rbac.yaml",
+		"config/deploy/trusted_ca_bundle_configmap.yaml",
 	}); err != nil {
 		return fmt.Errorf("deploy addon-operator-manager dependencies: %w", err)
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -356,7 +356,7 @@ func populateOLMBundleCache(imageCacheDir string) error {
 		{"cp", "-a", "config/olm/prometheus-role.yaml", manifestsDir},
 		{"cp", "-a", "config/olm/prometheus-rb.yaml", manifestsDir},
 		{"cp", "-a", "config/olm/annotations.yaml", metadataDir},
-
+		{"cp", "-a", "config/olm/trusted_ca_bundle_configmap.yaml", manifestsDir},
 		// copy CRDs
 		// The first few lines of the CRD file need to be removed:
 		// https://github.com/operator-framework/operator-registry/issues/222


### PR DESCRIPTION
ADO may fail when calling OCM when a cluster-wide proxy is enabled with a user-provided trust bundle. 
Updated the configuration to mount trusted CA bundle to the addon-operator-manager container 
JIRA: [MTSRE-1236](https://issues.redhat.com//browse/MTSRE-1236)