### PR TITLE
Removing SA token for addon-operator-manager

### DIFF
--- a/config/package/hcp/addon-operator-template.yaml
+++ b/config/package/hcp/addon-operator-template.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app.kubernetes.io/name: addon-operator
     spec:
+      automountServiceAccountToken: false
       containers:
         - args:
             - --secure-listen-address=0.0.0.0:8443


### PR DESCRIPTION
The addon-operator-manager has access to query KAS with default policy because it projects the SA token.
Removing the access by removing the token from the container. 

Ref. [MTSRE-1289](https://issues.redhat.com//browse/MTSRE-1289)