### PR TITLE
Make catalog pods compatible with restricted SCC enforcement

### DIFF
--- a/config/olm/catalog-source.yaml
+++ b/config/olm/catalog-source.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: olm
 spec:
   sourceType: grpc
+  grpcPodConfig:
+    securityContextConfig: restricted
   publisher: Red Hat
   displayName: MTSRE Addon Operator
   image: quay.io/app-sre/addon-operator-index:main

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -56,6 +56,8 @@ objects:
             namespace: openshift-addon-operator
           spec:
             sourceType: grpc
+            grpcPodConfig:
+              securityContextConfig: restricted
             image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
             displayName: MTSRE Addon Operator
             publisher: Red Hat


### PR DESCRIPTION
Making sure that the operator catalog pod is compatible with restricted SCC enforcement (OCPBU-90)

Ref: OSD-15628