### PR TITLE
Revert "Making sure that the operator catalog pod is compatible with …

### DIFF
--- a/config/olm/catalog-source.yaml
+++ b/config/olm/catalog-source.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: olm
 spec:
   sourceType: grpc
-  grpcPodConfig:
-    securityContextConfig: restricted
   publisher: Red Hat
   displayName: MTSRE Addon Operator
   image: quay.io/app-sre/addon-operator-index:main

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -56,8 +56,6 @@ objects:
             namespace: openshift-addon-operator
           spec:
             sourceType: grpc
-            grpcPodConfig:
-              securityContextConfig: restricted
             image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
             displayName: MTSRE Addon Operator
             publisher: Red Hat


### PR DESCRIPTION
…restricted SCC enforcement (OCPBU-90)"

This reverts commit 30d2af27025ce2ec8e21df864b4f2cd4c94fffa8.

These changes are incompatible with OpenShift <4.12 and must be reverted until we have a solution to split delivery of ADO based on OpenShift version.