### PR TITLE
[AUTH-388] set pod security admission labels for namespaces

### DIFF
--- a/config/deploy/00-namespace.yaml
+++ b/config/deploy/00-namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: addon-operator
+  labels:
+    pod-security.kubernetes.io/enforce: 'baseline'
+    pod-security.kubernetes.io/audit: 'baseline'
+    pod-security.kubernetes.io/warn: 'baseline'

--- a/config/deploy/api-mock/00-namespace.yaml
+++ b/config/deploy/api-mock/00-namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: api-mock
+  labels:
+    pod-security.kubernetes.io/enforce: 'baseline'
+    pod-security.kubernetes.io/audit: 'baseline'
+    pod-security.kubernetes.io/warn: 'baseline'

--- a/config/deploy/observability-operator/namespace.yaml
+++ b/config/deploy/observability-operator/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-observability-operator
+  labels:
+    pod-security.kubernetes.io/enforce: 'baseline'
+    pod-security.kubernetes.io/audit: 'baseline'
+    pod-security.kubernetes.io/warn: 'baseline'

--- a/config/deploy/prometheus-remote-storage-mock/namespace.yaml
+++ b/config/deploy/prometheus-remote-storage-mock/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: prometheus-remote-storage-mock
+  labels:
+    pod-security.kubernetes.io/enforce: 'baseline'
+    pod-security.kubernetes.io/audit: 'baseline'
+    pod-security.kubernetes.io/warn: 'baseline'

--- a/config/package/hc/namespace.yaml
+++ b/config/package/hc/namespace.yaml
@@ -4,3 +4,7 @@ metadata:
   name: addon-operator
   annotations:
     package-operator.run/phase: hosted-cluster
+  labels:
+    pod-security.kubernetes.io/enforce: 'baseline'
+    pod-security.kubernetes.io/audit: 'baseline'
+    pod-security.kubernetes.io/warn: 'baseline'

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -49,6 +49,9 @@ objects:
             name: openshift-addon-operator
             labels:
               openshift.io/cluster-monitoring: "true"
+              pod-security.kubernetes.io/enforce: 'baseline'
+              pod-security.kubernetes.io/audit: 'baseline'
+              pod-security.kubernetes.io/warn: 'baseline'
         - apiVersion: operators.coreos.com/v1alpha1
           kind: CatalogSource
           metadata:


### PR DESCRIPTION
This sets pod security admission labels. Currently, none are set and starting with OpenShift 4.13 this generates warnings in Telemetry. This fixes it.

Refer to https://kubernetes.io/docs/concepts/security/pod-security-standards/ to further tighten the labels potentially to the recommended `restricted` level.

The labels were determined by using the https://github.com/stlaz/psachecker tool.