### PR TITLE
refactor: return AddonInstanceClient for NewAddonInstanceClient() function

### DIFF
--- a/pkg/client/addon_instance.go
+++ b/pkg/client/addon_instance.go
@@ -19,9 +19,9 @@ type AddonInstanceClient interface {
 	SendPulse(ctx context.Context, instance av1alpha1.AddonInstance, opts ...SendPulseOption) error
 }
 
-// NewAddonInstanceClient returns a configured AddonInstanceClient implementation
+// NewAddonInstanceClient returns a configured AddonInstanceClient
 // using the given client instance as a base.
-func NewAddonInstanceClient(client client.Client) *AddonInstanceClientImpl {
+func NewAddonInstanceClient(client client.Client) AddonInstanceClient {
 	return &AddonInstanceClientImpl{
 		client: client,
 	}

--- a/pkg/client/addon_instance_test.go
+++ b/pkg/client/addon_instance_test.go
@@ -71,7 +71,7 @@ func TestAddonInstanceClientImplSendPulse(t *testing.T) {
 				),
 				NewAddonInstanceConditionReadyToBeDeleted(
 					metav1.ConditionTrue,
-					av1alpha1.AddonReasonReadyToBeDeleted,
+					av1alpha1.AddonInstanceReasonReadyToBeDeleted,
 					"Ready to be deleted",
 				),
 			},


### PR DESCRIPTION
* Use the interface `AddonInstanceClient` as the return type of `NewAddonInstanceClient()` function
  *  This makes it easier for underlying services to mock the client if necessary for their own unit tests
  * Also generally better to return interface to decouple the implementation with the return type
* Minor fix/nit in unit test to use the correct `AddonInstanceReason` rather than an `AddonReason` in the status condition function