### PR TITLE
fix: use addonsv1alpha1.AddonInstanceConditionReadyToBeDeleted.String()

### DIFF
--- a/integration/addon_test.go
+++ b/integration/addon_test.go
@@ -530,7 +530,7 @@ func (s *integrationTestSuite) TestAddonDeletionFlow() {
 		// We act like the addon's operator and add the ready to deleted condition to our addon instance.
 
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    string(addonsv1alpha1.AddonInstanceConditionReadyToBeDeleted),
+			Type:    addonsv1alpha1.AddonInstanceConditionReadyToBeDeleted.String(),
 			Reason:  addonsv1alpha1.AddonInstanceReasonReadyToBeDeleted.String(),
 			Message: "Cleanup up resources.",
 			Status:  metav1.ConditionTrue,
@@ -685,7 +685,7 @@ func (s *integrationTestSuite) TestAddonDeletionFlow() {
 
 		// We act like the addon's operator and add the ready to deleted condition to our addon instance.
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    string(addonsv1alpha1.AddonInstanceConditionReadyToBeDeleted),
+			Type:    addonsv1alpha1.AddonInstanceConditionReadyToBeDeleted.String(),
 			Reason:  addonsv1alpha1.AddonInstanceReasonReadyToBeDeleted.String(),
 			Message: "Cleanup up resources.",
 			Status:  metav1.ConditionTrue,

--- a/internal/controllers/addon/addon_deletion_handler_addon_instance.go
+++ b/internal/controllers/addon/addon_deletion_handler_addon_instance.go
@@ -68,7 +68,7 @@ func hasReadyToBeDeletedStatusCondition(
 	instance *addonsv1alpha1.AddonInstance, expectedValue metav1.ConditionStatus) bool {
 	requiredCond := meta.FindStatusCondition(
 		instance.Status.Conditions,
-		string(addonsv1alpha1.AddonInstanceConditionReadyToBeDeleted),
+		addonsv1alpha1.AddonInstanceConditionReadyToBeDeleted.String(),
 	)
 	if requiredCond == nil {
 		return false

--- a/internal/controllers/addon/addon_deletion_handler_addon_instance_test.go
+++ b/internal/controllers/addon/addon_deletion_handler_addon_instance_test.go
@@ -130,7 +130,7 @@ func TestAckReceivedFromAddonStrategyNew(t *testing.T) {
 				Status: addonsv1alpha1.AddonInstanceStatus{
 					Conditions: []v1.Condition{
 						{
-							Type:   string(addonsv1alpha1.AddonInstanceConditionReadyToBeDeleted),
+							Type:   addonsv1alpha1.AddonInstanceConditionReadyToBeDeleted.String(),
 							Status: v1.ConditionUnknown,
 						},
 					},
@@ -145,7 +145,7 @@ func TestAckReceivedFromAddonStrategyNew(t *testing.T) {
 				Status: addonsv1alpha1.AddonInstanceStatus{
 					Conditions: []v1.Condition{
 						{
-							Type:   string(addonsv1alpha1.AddonInstanceConditionReadyToBeDeleted),
+							Type:   addonsv1alpha1.AddonInstanceConditionReadyToBeDeleted.String(),
 							Status: v1.ConditionTrue,
 						},
 					},

--- a/pkg/client/addon_instance.go
+++ b/pkg/client/addon_instance.go
@@ -77,6 +77,12 @@ func NewAddonInstanceConditionInstalled(status metav1.ConditionStatus, reason av
 	return newAddonInstanceCondition(av1alpha1.AddonInstanceConditionInstalled, status, reason.String(), msg)
 }
 
+// NewAddonInstanceConditionReadyToBeDeleted returns an AddonInstanceReadyToBeDeleted status condition
+// with the given status, reason, and message.
+func NewAddonInstanceConditionReadyToBeDeleted(status metav1.ConditionStatus, reason av1alpha1.AddonInstanceReadyToBeDeleted, msg string) metav1.Condition {
+	return newAddonInstanceCondition(av1alpha1.AddonInstanceConditionReadyToBeDeleted, status, reason.String(), msg)
+}
+
 func newAddonInstanceCondition(cond av1alpha1.AddonInstanceCondition, status metav1.ConditionStatus, reason, msg string) metav1.Condition {
 	return metav1.Condition{
 		Type:    cond.String(),

--- a/pkg/client/addon_instance_test.go
+++ b/pkg/client/addon_instance_test.go
@@ -45,7 +45,7 @@ func TestAddonInstanceClientImplSendPulse(t *testing.T) {
 			},
 			Conditions: []metav1.Condition{
 				NewAddonInstanceConditionInstalled(
-					"True",
+					metav1.ConditionTrue,
 					av1alpha1.AddonInstanceInstalledReasonSetupComplete,
 					"All components up",
 				),
@@ -60,14 +60,19 @@ func TestAddonInstanceClientImplSendPulse(t *testing.T) {
 			},
 			Conditions: []metav1.Condition{
 				NewAddonInstanceConditionInstalled(
-					"True",
+					metav1.ConditionFalse,
 					av1alpha1.AddonInstanceInstalledReasonSetupComplete,
 					"All components up",
 				),
 				NewAddonInstanceConditionDegraded(
-					"True",
+					metav1.ConditionTrue,
 					"ServiceXUnavailable",
 					"Service X database is unreachable",
+				),
+				NewAddonInstanceConditionReadyToBeDeleted(
+					metav1.ConditionTrue,
+					av1alpha1.AddonReasonReadyToBeDeleted,
+					"Ready to be deleted",
 				),
 			},
 		},


### PR DESCRIPTION
* Use `addonsv1alpha1.AddonInstanceConditionReadyToBeDeleted.String()` as the condition type for detecting addon is ready to be deleted from addon instance
  * Previous to this `ReadyToBeDeleted` would have been used rather than `addons.managed.openshift.io/ReadyToBeDeleted` as the condition type
* Provide `NewAddonInstanceConditionReadyToBeDeleted` function so that clients can call this function instead of manually creating the condition status which may lead to user error with using the wrong condition type 