### PR TITLE
Feat: Influence 'Installed' condition by addon's dependencies

### DIFF
--- a/apis/addons/v1alpha1/addons_types.go
+++ b/apis/addons/v1alpha1/addons_types.go
@@ -48,6 +48,11 @@ type AddonSpec struct {
 	// +optional
 	DeleteAckRequired bool `json:"deleteAckRequired"`
 
+	// Defines if the addon needs installation acknowledgment
+	// from its corresponding addon instance.
+	// +optional
+	InstallAckRequired bool `json:"installAckRequired"`
+
 	// UpgradePolicy enables status reporting via upgrade policies.
 	UpgradePolicy *AddonUpgradePolicy `json:"upgradePolicy,omitempty"`
 
@@ -313,6 +318,9 @@ const (
 
 	// Addon has timed out waiting for acknowledgement from the underlying addon.
 	AddonReasonDeletionTimedOut = "AddonReasonDeletionTimedOut"
+
+	// Addon Instance is not yet installed.
+	AddonReasonInstanceNotInstalled = "AddonInstanceNotInstalled"
 )
 
 type AddonNamespace struct {

--- a/config/deploy/addons.managed.openshift.io_addons.yaml
+++ b/config/deploy/addons.managed.openshift.io_addons.yaml
@@ -237,6 +237,10 @@ spec:
                 required:
                 - type
                 type: object
+              installAckRequired:
+                description: Defines if the addon needs installation acknowledgment
+                  from its corresponding addon instance.
+                type: boolean
               monitoring:
                 description: Defines how an addon is monitored.
                 properties:

--- a/config/openshift/manifests/addons.crd.yaml
+++ b/config/openshift/manifests/addons.crd.yaml
@@ -235,6 +235,10 @@ spec:
                 required:
                 - type
                 type: object
+              installAckRequired:
+                description: Defines if the addon needs installation acknowledgment
+                  from its corresponding addon instance.
+                type: boolean
               monitoring:
                 description: Defines how an addon is monitored.
                 properties:

--- a/docs/api-reference/_index.md
+++ b/docs/api-reference/_index.md
@@ -323,6 +323,7 @@ AddonSpec defines the desired state of Addon.
 | correlationID | Correlation ID for co-relating current AddonCR revision and reported status. | string | false |
 | install | Defines how an Addon is installed. This field is immutable. | [AddonInstallSpec.addons.managed.openshift.io/v1alpha1](#addoninstallspecaddonsmanagedopenshiftiov1alpha1) | true |
 | deleteAckRequired | Defines whether the addon needs acknowledgment from the underlying addon's operator before deletion. | bool | true |
+| installAckRequired | Defines if the addon needs installation acknowledgment from its corresponding addon instance. | bool | true |
 | upgradePolicy | UpgradePolicy enables status reporting via upgrade policies. | *[AddonUpgradePolicy.addons.managed.openshift.io/v1alpha1](#addonupgradepolicyaddonsmanagedopenshiftiov1alpha1) | false |
 | monitoring | Defines how an addon is monitored. | *[MonitoringSpec.addons.managed.openshift.io/v1alpha1](#monitoringspecaddonsmanagedopenshiftiov1alpha1) | false |
 | secretPropagation | Settings for propagating secrets from the Addon Operator install namespace into Addon namespaces. | *[AddonSecretPropagation.addons.managed.openshift.io/v1alpha1](#addonsecretpropagationaddonsmanagedopenshiftiov1alpha1) | false |

--- a/integration/addon_test.go
+++ b/integration/addon_test.go
@@ -338,6 +338,7 @@ func (s *integrationTestSuite) TestAddonConditions() {
 		s.Require().NoError(err)
 
 		// wait until Addon has installed=true.
+		// i.e; Addon Instance has been installed & CSV phase has succeeded.
 		err = integration.WaitForObject(
 			ctx,
 			s.T(), defaultAddonAvailabilityTimeout, addon, "to be installed",
@@ -387,7 +388,6 @@ func (s *integrationTestSuite) TestAddonConditions() {
 		}
 		err = integration.Client.Create(ctx, deleteConfigMap)
 		s.Require().NoError(err)
-
 		// wait for installed=false condition to be reported.
 		err = integration.WaitForObject(
 			ctx,

--- a/integration/fixtures_test.go
+++ b/integration/fixtures_test.go
@@ -114,8 +114,10 @@ func addonWithVersion(version string, catalogSrc string) *addonsv1alpha1.Addon {
 		},
 		Spec: addonsv1alpha1.AddonSpec{
 			DeleteAckRequired: true,
-			Version:           version,
-			DisplayName:       "addon-oisafbo12",
+			// TODO: Modify reference-addon to report addon instance as installed without depending on the addon's availability
+			// InstallAckRequired: true,
+			Version:     version,
+			DisplayName: "addon-oisafbo12",
 			Namespaces: []addonsv1alpha1.AddonNamespace{
 				{Name: "namespace-onbgdions"},
 				{Name: "namespace-pioghfndb"},

--- a/internal/controllers/addon/utils.go
+++ b/internal/controllers/addon/utils.go
@@ -112,6 +112,7 @@ func reportReadinessStatus(addon *addonsv1alpha1.Addon) {
 	meta.SetStatusCondition(&addon.Status.Conditions, metav1.Condition{
 		Type:               addonsv1alpha1.Available,
 		Status:             metav1.ConditionTrue,
+		Message:            "All components are ready.",
 		Reason:             addonsv1alpha1.AddonReasonFullyReconciled,
 		ObservedGeneration: addon.Generation,
 	})
@@ -172,7 +173,7 @@ func reportAddonReadyToBeDeletedStatus(addon *addonsv1alpha1.Addon, value metav1
 			Type:               addonsv1alpha1.ReadyToBeDeleted,
 			Status:             value,
 			Reason:             addonsv1alpha1.AddonReasonReadyToBeDeleted,
-			Message:            "Addon is ready to deleted.",
+			Message:            "Addon is ready to be deleted.",
 			ObservedGeneration: addon.Generation,
 		})
 		addon.Status.ObservedGeneration = addon.Generation
@@ -181,7 +182,7 @@ func reportAddonReadyToBeDeletedStatus(addon *addonsv1alpha1.Addon, value metav1
 			Type:               addonsv1alpha1.ReadyToBeDeleted,
 			Status:             value,
 			Reason:             addonsv1alpha1.AddonReasonNotReadyToBeDeleted,
-			Message:            "Addon is not yet ready to deleted.",
+			Message:            "Addon is not yet ready to be deleted.",
 			ObservedGeneration: addon.Generation,
 		})
 		addon.Status.ObservedGeneration = addon.Generation
@@ -193,7 +194,7 @@ func reportAddonDeletionTimedOut(addon *addonsv1alpha1.Addon) {
 		Type:               addonsv1alpha1.DeleteTimeout,
 		Status:             metav1.ConditionTrue,
 		Reason:             addonsv1alpha1.AddonReasonDeletionTimedOut,
-		Message:            "Addon deletion is timed out.",
+		Message:            "Addon deletion has timed out.",
 		ObservedGeneration: addon.Generation,
 	})
 	addon.Status.ObservedGeneration = addon.Generation
@@ -327,8 +328,13 @@ func reportUnreadyCSV(addon *addonsv1alpha1.Addon, message string) {
 	reportPendingStatus(addon, addonsv1alpha1.AddonReasonUnreadyCSV,
 		fmt.Sprintf("ClusterServiceVersion is not ready: %s", message))
 }
+
 func reportMissingCSV(addon *addonsv1alpha1.Addon) {
 	reportPendingStatus(addon, addonsv1alpha1.AddonReasonMissingCSV, "ClusterServiceVersion is missing.")
+}
+
+func reportPendingAddonInstanceInstallation(addon *addonsv1alpha1.Addon) {
+	reportPendingStatus(addon, addonsv1alpha1.AddonReasonInstanceNotInstalled, "Addon instance is not yet installed.")
 }
 
 func reportUnreadyMonitoringFederation(addon *addonsv1alpha1.Addon, message string) {


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / Why we need it?
Currently, if the underlying addon's CSV initially starts up in a succeeded state, ADO reports the `Installed=true` condition on the addon CR. This method disregards the dependency of the addon on its addon instance. While tenants are looking to onboard the AddOn Instance API for better status reporting, this PR ensures that ADO considers the addon instance status condition while reporting the addon's installation status.

**Addon status reporting:-**
- Wait for the addon's operator to report its addon instance as installed before setting `Installed=True` status condition in the addon.

### Which Jira/Github issue(s) does this PR fix?
Resolves: https://issues.redhat.com/browse/MTSRE-1393

### Pre-checks (if applicable)
- [x] Ran unit tests locally
- [ ] Validated the changes in a cluster
- [ ] Included documentation changes with PR 
  TODO: Update enhancement documentation.