### PR TITLE
Add reason label

### DIFF
--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -93,6 +93,7 @@ func TestAddonMetrics_AddonHealth(t *testing.T) {
 				{
 					Type:   addonsv1alpha1.Available,
 					Status: metav1.ConditionFalse,
+					Reason: addonsv1alpha1.AddonReasonUnreadyCSV,
 				},
 			}),
 			expected: float64(0),
@@ -102,6 +103,7 @@ func TestAddonMetrics_AddonHealth(t *testing.T) {
 				{
 					Type:   addonsv1alpha1.Available,
 					Status: metav1.ConditionTrue,
+					Reason: addonsv1alpha1.AddonReasonFullyReconciled,
 				},
 			}),
 			expected: float64(1),
@@ -127,10 +129,12 @@ func TestAddonMetrics_AddonHealth(t *testing.T) {
 			// local copy of the addon
 			addon := tc.addon.DeepCopy()
 			addon.Name = fmt.Sprintf("%s-%d", addonNamePrefix, i)
+			addonConditions := addon.Status.Conditions
 
-			healthReason := ""
-			if len(addon.Status.Conditions) == 0 {
-				healthReason = "Unknown"
+			healthReason := "Unknown"
+
+			if len(addonConditions) != 0 {
+				healthReason = addonConditions[0].Reason
 			}
 
 			recorder.recordAddonHealthInfo(addon)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -128,11 +128,17 @@ func TestAddonMetrics_AddonHealth(t *testing.T) {
 			addon := tc.addon.DeepCopy()
 			addon.Name = fmt.Sprintf("%s-%d", addonNamePrefix, i)
 
+			healthReason := ""
+			if len(addon.Status.Conditions) == 0 {
+				healthReason = "Unknown"
+			}
+
 			recorder.recordAddonHealthInfo(addon)
 			assert.Equal(t, float64(tc.expected), testutil.ToFloat64(
 				recorder.addonHealthInfo.WithLabelValues(
 					addon.Name,
 					"0.0.0",
+					healthReason,
 				),
 			))
 		})


### PR DESCRIPTION
### What type of PR is this?
Refactor

### What this PR does / why we need it?
Adds the `reason` label to the `addon_operator_addon_health_info` metric.

Induces cardinality with deduplication of the metric making it less ambiguous.
```
# HELP addon_operator_addon_health_info Addon Health information
# TYPE addon_operator_addon_health_info gauge
addon_operator_addon_health_info{_id="a440b136-b2d6-406b-a884-fca2d62cd170",name="reference-addon",reason="FullyReconciled",version="1.0.0"} 1
# HELP addon_operator_addons_count Total number of Addon installations, grouped by 'available', 'paused' and 'total'
```

### Which Jira/Github issue(s) this PR fixes?
Resolves: https://issues.redhat.com/browse/MTSRE-1336

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make test-unit` command locally to run all the unit tests and mock tests locally.
