### PR TITLE
fix: Bump ubi8 images and go

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/addon-operator/apis
 
-go 1.18
+go 1.19
 
 require (
 	github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring v0.61.1-rhobs1

--- a/config/docker/addon-operator-manager.Dockerfile
+++ b/config/docker/addon-operator-manager.Dockerfile
@@ -1,15 +1,14 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:3e1adcc31c6073d010b8043b070bd089d7bf37ee2c397c110211a6273453433f
-# registry.access.redhat.com/ubi8/ubi-minimal:8.7-1107
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1014
 
 # shadow-utils contains adduser and groupadd binaries
 RUN microdnf install shadow-utils \
 	&& groupadd --gid 1000 noroot \
 	&& adduser \
-		--no-create-home \
-		--no-user-group \
-		--uid 1000 \
-		--gid 1000 \
-		noroot
+	--no-create-home \
+	--no-user-group \
+	--uid 1000 \
+	--gid 1000 \
+	noroot
 
 WORKDIR /
 

--- a/config/docker/addon-operator-webhook.Dockerfile
+++ b/config/docker/addon-operator-webhook.Dockerfile
@@ -1,15 +1,14 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:3e1adcc31c6073d010b8043b070bd089d7bf37ee2c397c110211a6273453433f
-# registry.access.redhat.com/ubi8/ubi-minimal:8.7-1107
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1014
 
 # shadow-utils contains adduser and groupadd binaries
 RUN microdnf install shadow-utils \
 	&& groupadd --gid 1000 noroot \
 	&& adduser \
-		--no-create-home \
-		--no-user-group \
-		--uid 1000 \
-		--gid 1000 \
-		noroot
+	--no-create-home \
+	--no-user-group \
+	--uid 1000 \
+	--gid 1000 \
+	noroot
 
 WORKDIR /
 

--- a/config/docker/api-mock.Dockerfile
+++ b/config/docker/api-mock.Dockerfile
@@ -1,15 +1,14 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:3e1adcc31c6073d010b8043b070bd089d7bf37ee2c397c110211a6273453433f
-# registry.access.redhat.com/ubi8/ubi-minimal:8.7-1107
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1014
 
 # shadow-utils contains adduser and groupadd binaries
 RUN microdnf install shadow-utils \
 	&& groupadd --gid 1000 noroot \
 	&& adduser \
-		--no-create-home \
-		--no-user-group \
-		--uid 1000 \
-		--gid 1000 \
-		noroot
+	--no-create-home \
+	--no-user-group \
+	--uid 1000 \
+	--gid 1000 \
+	noroot
 
 WORKDIR /
 

--- a/config/docker/prometheus-remote-storage-mock.Dockerfile
+++ b/config/docker/prometheus-remote-storage-mock.Dockerfile
@@ -1,15 +1,14 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:3e1adcc31c6073d010b8043b070bd089d7bf37ee2c397c110211a6273453433f
-# registry.access.redhat.com/ubi8/ubi-minimal:8.7-1107
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1014
 
 # shadow-utils contains adduser and groupadd binaries
 RUN microdnf install shadow-utils \
 	&& groupadd --gid 1000 noroot \
 	&& adduser \
-		--no-create-home \
-		--no-user-group \
-		--uid 1000 \
-		--gid 1000 \
-		noroot
+	--no-create-home \
+	--no-user-group \
+	--uid 1000 \
+	--gid 1000 \
+	noroot
 
 WORKDIR /
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/addon-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
### What type of PR is this?
Fix

### What this PR does / why we need it?
- Bumps go version to 1.19.
- Bumps ubi8 images.

### Special notes for your reviewer:
No dependency updates are intended, deps are updated by dependabot.