### PR TITLE
fix: mount HC kubeconfig into metrics-relay-server container

### DIFF
--- a/config/package/hcp/addon-operator-template.yaml
+++ b/config/package/hcp/addon-operator-template.yaml
@@ -25,6 +25,7 @@ spec:
             - --tls-cert-file=/tmp/k8s-metrics-server/serving-certs/tls.crt
             - --tls-private-key-file=/tmp/k8s-metrics-server/serving-certs/tls.key
             - --logtostderr=true
+            - --kubeconfig=/etc/openshift/kubeconfig/kubeconfig
             - --ignore-paths=/metrics,/healthz
           image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
           livenessProbe:
@@ -40,6 +41,9 @@ spec:
             periodSeconds: 10
             tcpSocket:
               port: 8443
+          env:
+            - name: KUBECONFIG
+              value: /etc/openshift/kubeconfig/kubeconfig
           resources:
             limits:
               cpu: 100m
@@ -50,6 +54,9 @@ spec:
           volumeMounts:
             - mountPath: /tmp/k8s-metrics-server/serving-certs/
               name: tls
+              readOnly: true
+            - mountPath: /etc/openshift/kubeconfig
+              name: kubeconfig
               readOnly: true
         - args:
           - --enable-leader-election


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Following https://issues.redhat.com//browse/MTSRE-1289 the `metrics-relay-server` container has lost access to the cluster's API. Hence we need to explicitly mount the HCP Kubeconfig into the container.

```
F0823 06:58:56.102447       1 main.go:426] cannot find Service Account in pod to build in-cluster rest config: open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory
goroutine 1 [running]:
```
