### PR TITLE
Feat: Ensure FIPS compliance

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
-  name: release
-  namespace: openshift
-  tag: rhel-8-release-golang-1.19-openshift-4.12
+  name: builder
+  namespace: ocp
+  tag: rhel-8-golang-1.20-openshift-4.14

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GOLANGCI_LINT_VERSION:=v1.43.0
 OPM_VERSION:=v1.24.0
 
 # Build Flags
-export CGO_ENABLED:=0
+export CGO_ENABLED:=1
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 SHORT_SHA=$(shell git rev-parse --short HEAD)
 VERSION?=${SHORT_SHA}

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/addon-operator/apis
 
-go 1.19
+go 1.20
 
 require (
 	github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring v0.61.1-rhobs1

--- a/config/docker/Dockerfile.src.ci
+++ b/config/docker/Dockerfile.src.ci
@@ -1,3 +1,5 @@
-FROM src
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+
 RUN yum update -y && yum install -y python3 python3-pip
+
 RUN pip3 install pre-commit

--- a/config/docker/addon-operator-bundle.Dockerfile
+++ b/config/docker/addon-operator-bundle.Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/

--- a/config/docker/addon-operator-manager.Dockerfile
+++ b/config/docker/addon-operator-manager.Dockerfile
@@ -1,19 +1,14 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1014
-
-# shadow-utils contains adduser and groupadd binaries
-RUN microdnf install shadow-utils \
-	&& groupadd --gid 1000 noroot \
-	&& adduser \
-	--no-create-home \
-	--no-user-group \
-	--uid 1000 \
-	--gid 1000 \
-	noroot
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
 
 WORKDIR /
 
 COPY addon-operator-manager /usr/local/bin/
 
 USER 1001
+
+ENV CGO_ENABLED=1
+
+# force the binary to behave as if FIPS mode were enabled.
+ENV OPENSSL_FORCE_FIPS_MODE=1
 
 ENTRYPOINT ["/usr/local/bin/addon-operator-manager"]

--- a/config/docker/addon-operator-webhook.Dockerfile
+++ b/config/docker/addon-operator-webhook.Dockerfile
@@ -1,19 +1,14 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1014
-
-# shadow-utils contains adduser and groupadd binaries
-RUN microdnf install shadow-utils \
-	&& groupadd --gid 1000 noroot \
-	&& adduser \
-	--no-create-home \
-	--no-user-group \
-	--uid 1000 \
-	--gid 1000 \
-	noroot
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
 
 WORKDIR /
 
 COPY addon-operator-webhook /usr/local/bin/
 
 USER 1001
+
+ENV CGO_ENABLED=1
+
+# force the binary to behave as if FIPS mode were enabled.
+ENV OPENSSL_FORCE_FIPS_MODE=1
 
 ENTRYPOINT ["/usr/local/bin/addon-operator-webhook"]

--- a/config/docker/api-mock.Dockerfile
+++ b/config/docker/api-mock.Dockerfile
@@ -1,19 +1,14 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1014
-
-# shadow-utils contains adduser and groupadd binaries
-RUN microdnf install shadow-utils \
-	&& groupadd --gid 1000 noroot \
-	&& adduser \
-	--no-create-home \
-	--no-user-group \
-	--uid 1000 \
-	--gid 1000 \
-	noroot
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
 
 WORKDIR /
 
 COPY api-mock /usr/local/bin/
 
 USER 1001
+
+ENV CGO_ENABLED=1
+
+# force the binary to behave as if FIPS mode were enabled.
+ENV OPENSSL_FORCE_FIPS_MODE=1
 
 ENTRYPOINT ["/usr/local/bin/api-mock"]

--- a/config/docker/app-interface-push-images.Dockerfile
+++ b/config/docker/app-interface-push-images.Dockerfile
@@ -1,12 +1,16 @@
-FROM quay.io/podman/stable
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
 
-RUN yum install -y \
-  python3-pip make ncurses git && \
-  pip3 install pre-commit && \
-  curl -L --fail https://go.dev/dl/go1.19.7.linux-amd64.tar.gz > /tmp/go.tar.gz && \
-  rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go.tar.gz
+# Install go1.20.6
+RUN dnf install -y \
+  http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/golang/1.20.6/1.module+el8.9.0+19500+fa91430b/x86_64/golang-1.20.6-1.module+el8.9.0+19500+fa91430b.x86_64.rpm \
+  http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/golang/1.20.6/1.module+el8.9.0+19500+fa91430b/x86_64/golang-bin-1.20.6-1.module+el8.9.0+19500+fa91430b.x86_64.rpm \
+  http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/golang/1.20.6/1.module+el8.9.0+19500+fa91430b/noarch/golang-src-1.20.6-1.module+el8.9.0+19500+fa91430b.noarch.rpm \
+  python3-pip make ncurses git podman gcc && \
+  pip3 install pre-commit
 
 ENV PATH="/usr/local/go/bin:${PATH}"
+
+ENV CGO_ENABLED=1
 
 WORKDIR /workdir
 

--- a/config/docker/prometheus-remote-storage-mock.Dockerfile
+++ b/config/docker/prometheus-remote-storage-mock.Dockerfile
@@ -1,19 +1,14 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1014
-
-# shadow-utils contains adduser and groupadd binaries
-RUN microdnf install shadow-utils \
-	&& groupadd --gid 1000 noroot \
-	&& adduser \
-	--no-create-home \
-	--no-user-group \
-	--uid 1000 \
-	--gid 1000 \
-	noroot
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
 
 WORKDIR /
 
 COPY prometheus-remote-storage-mock /usr/local/bin/
 
 USER 1001
+
+ENV CGO_ENABLED=1
+
+# force the binary to behave as if FIPS mode were enabled.
+ENV OPENSSL_FORCE_FIPS_MODE=1
 
 ENTRYPOINT ["/usr/local/bin/prometheus-remote-storage-mock"]

--- a/config/openshift/addon-operator-bundle.Dockerfile
+++ b/config/openshift/addon-operator-bundle.Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/addon-operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
This PR makes the addon-operator FIPS compliant.

**Notable changes:-**
- Bumps root image to support go1.20.
- Bumps go to 1.20.
- Dockerfile base images default to ubi8-minimal.
- Enforce `CGO_ENABLED=1` and OpenSSL while running binaries.

### Which Jira/Github issue(s) this PR fixes?
Resolves: https://issues.redhat.com/browse/MTSRE-1445
