### PR TITLE
fix: update base image to ubi8

### DIFF
--- a/config/docker/Dockerfile.src.ci
+++ b/config/docker/Dockerfile.src.ci
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
 
 RUN yum update -y && yum install -y python3 python3-pip
 

--- a/config/docker/addon-operator-bundle.Dockerfile
+++ b/config/docker/addon-operator-bundle.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/

--- a/config/docker/addon-operator-manager.Dockerfile
+++ b/config/docker/addon-operator-manager.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
 
 WORKDIR /
 

--- a/config/docker/addon-operator-webhook.Dockerfile
+++ b/config/docker/addon-operator-webhook.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
 
 WORKDIR /
 

--- a/config/docker/api-mock.Dockerfile
+++ b/config/docker/api-mock.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
 
 WORKDIR /
 

--- a/config/docker/app-interface-push-images.Dockerfile
+++ b/config/docker/app-interface-push-images.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
 
 # Install go1.20.6
 RUN dnf install -y \

--- a/config/docker/prometheus-remote-storage-mock.Dockerfile
+++ b/config/docker/prometheus-remote-storage-mock.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
 
 WORKDIR /
 

--- a/config/openshift/addon-operator-bundle.Dockerfile
+++ b/config/openshift/addon-operator-bundle.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Update the base image from `ubi8-minimal` to `ubi8` as we need `yum` and `dnf` packages instead of `microdnf`.

### Which Jira/Github issue(s) this PR fixes?

Fixes failining build pipeline: https://ci.int.devshift.net/view/osd-operators/job/openshift-addon-operator-gh-build-main/427
