### PR TITLE
adding make scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ ENABLE_WEBHOOK?="false"
 ENABLE_MONITORING?="false"
 ENABLE_REMOTE_STORAGE_MOCK="true"
 WEBHOOK_PORT?=8080
+GOVULNCHECK_VERSION=v1.0.1
 
 # Container
 IMAGE_ORG?=quay.io/app-sre
@@ -304,3 +305,9 @@ push-image-%:
 # cleans the config/openshift folder for addon-operator-bundle openshift test folder
 clean-config-openshift:
 	@rm -rf "config/openshift/*"
+
+ensure-govulncheck:
+	@ls $(GOPATH)/bin/govulncheck 1>/dev/null || go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
+
+scan: ensure-govulncheck
+	govulncheck ./...


### PR DESCRIPTION
https://issues.redhat.com/browse/MTSRE-1413

@supreeth7 I have added the make target and written it so that it installs govulncheck if it does not exist.

I now (after doing the codecov changes) see how to add it to ci as well and will make those changes if these are approved.