### PR TITLE
added rbac for installplans

### DIFF
--- a/config/olm/addon-operator.csv.tpl.yaml
+++ b/config/olm/addon-operator.csv.tpl.yaml
@@ -114,6 +114,7 @@ spec:
           resources:
           - clusterserviceversions
           - operators
+          - installplans
           verbs:
           - watch
           - get


### PR DESCRIPTION
### What type of PR is this?
_bug_


### What this PR does / why we need it?
While testing v1.13.7 in staging, the following RBAC error was encountered. There is not enough stack trace in the logs to exactly determine where this error happened, but knowing that the changes in v1.13.7 has a line where it was getting an installplan, this might be the cause of the error. 

This PR adds perms for ADO to list installplans.

```
E1012 22:25:41.071818       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.8/tools/cache/reflector.go:169: Failed to watch *v1alpha1.InstallPlan: failed to list *v1alpha1.InstallPlan: installplans.operators.coreos.com is forbidden: User "system:serviceaccount:openshift-addon-operator:addon-operator" cannot list resource "installplans" in API group "operators.coreos.com" at the cluster scope
```

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[MTSRE-1512](https://issues.redhat.com//browse/MTSRE-1512)

### Special notes for your reviewer:

- I'm not 100% sure whether I update this CSV template or the CSV itself, I don't see any documentation. But it looks like ADO CSV is generated from the magefile, so I just updated this template. Please confirm.