### PR TITLE
fix: Update RBAC & add int test

### DIFF
--- a/config/deploy/rbac.yaml
+++ b/config/deploy/rbac.yaml
@@ -101,6 +101,7 @@ rules:
   - operatorgroups
   - catalogsources
   - subscriptions
+  - installplans
   verbs:
   - create
   - delete

--- a/config/olm/addon-operator.csv.tpl.yaml
+++ b/config/olm/addon-operator.csv.tpl.yaml
@@ -101,6 +101,7 @@ spec:
           - operatorgroups
           - catalogsources
           - subscriptions
+          - installplans
           verbs:
           - create
           - delete

--- a/config/openshift/manifests/addon-operator.csv.yaml
+++ b/config/openshift/manifests/addon-operator.csv.yaml
@@ -101,6 +101,7 @@ spec:
           - operatorgroups
           - catalogsources
           - subscriptions
+          - installplans
           verbs:
           - create
           - delete


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
- Updates ADO RBAC for it to be able to list `InstallPlan`.
- Also adds integration tests to verify the 'Installplan pending manual approval' state is reflected in the addon CR.

### Which Jira/Github issue(s) this PR fixes?
N/A

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make test-unit` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR
- [x] Squashed your commits
