### PR TITLE
developing

### DIFF
--- a/cmd/addon-operator-manager/main.go
+++ b/cmd/addon-operator-manager/main.go
@@ -77,9 +77,8 @@ func initReconcilers(mgr ctrl.Manager,
 	clusterExternalID := string(cv.Spec.ClusterID)
 
 	// Create metrics recorder
-	var recorder *metrics.Recorder
 	if enableRecorder {
-		recorder = metrics.NewRecorder(true, clusterExternalID)
+		metrics.NewRecorder(true, clusterExternalID)
 	}
 
 	addonReconciler := addoncontroller.NewAddonReconciler(
@@ -87,7 +86,6 @@ func initReconcilers(mgr ctrl.Manager,
 		uncachedClient,
 		ctrl.Log.WithName("controllers").WithName("Addon"),
 		mgr.GetScheme(),
-		recorder,
 		clusterExternalID,
 		namespace,
 		enableStatusReporting,
@@ -104,7 +102,6 @@ func initReconcilers(mgr ctrl.Manager,
 		Scheme:              mgr.GetScheme(),
 		GlobalPauseManager:  addonReconciler,
 		OCMClientManager:    addonReconciler,
-		Recorder:            recorder,
 		ClusterExternalID:   clusterExternalID,
 		FeatureTogglesState: strings.Split(addonOperatorInCluster.Spec.FeatureFlags, ","),
 	}).SetupWithManager(mgr); err != nil {

--- a/internal/controllers/addon/monitoring_federation_reconciler.go
+++ b/internal/controllers/addon/monitoring_federation_reconciler.go
@@ -44,14 +44,19 @@ func (r *monitoringFederationReconciler) Reconcile(ctx context.Context,
 
 		return ctrl.Result{}, nil
 	} else if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to ensure ServiceMonitor: %w", err)
+		err = errors.Join(err, controllers.ErrEnsureCreateServiceMonitor)
+		return ctrl.Result{}, err
 	} else if !result.IsZero() {
 		return result, nil
 	}
 
 	// Remove possibly unwanted monitoring federation
 	if err := r.ensureDeletionOfUnwantedMonitoringFederation(ctx, addon); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to ensure deletion of unwanted ServiceMonitors: %w", err)
+		err = errors.Join(
+			err,
+			controllers.ErrEnsureDeleteUnwantedServiceMonitor,
+		)
+		return ctrl.Result{}, err
 	}
 	return reconcile.Result{}, nil
 }

--- a/internal/controllers/addon/monitoring_stack_reconciler.go
+++ b/internal/controllers/addon/monitoring_stack_reconciler.go
@@ -44,6 +44,7 @@ func (r *monitoringStackReconciler) Reconcile(ctx context.Context,
 		if errors.Is(err, errMonitoringStackSpecNotFound) {
 			return reconcile.Result{}, nil
 		}
+		err = errors.Join(err, controllers.ErrEnsureCreateMonitoringStack)
 		return reconcile.Result{}, err
 	}
 

--- a/internal/controllers/addon/namespace_reconciler.go
+++ b/internal/controllers/addon/namespace_reconciler.go
@@ -2,6 +2,7 @@ package addon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -30,14 +31,16 @@ func (r *namespaceReconciler) Reconcile(ctx context.Context,
 	// Ensure wanted namespaces
 	result, err := r.ensureWantedNamespaces(ctx, addon)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to ensure wanted Namespaces: %w", err)
+		err = errors.Join(err, controllers.ErrEnsureCreateNamespaces)
+		return ctrl.Result{}, err
 	} else if !result.IsZero() {
 		return result, nil
 	}
 
 	// Ensure unwanted namespaces are removed
 	if err := r.ensureDeletionOfUnwantedNamespaces(ctx, addon); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to ensure deletion of unwanted Namespaces: %w", err)
+		err = errors.Join(err, controllers.ErrEnsureDeleteNamespaces)
+		return ctrl.Result{}, err
 	}
 	return reconcile.Result{}, nil
 }

--- a/internal/controllers/addon/secret_reconciler.go
+++ b/internal/controllers/addon/secret_reconciler.go
@@ -2,10 +2,11 @@ package addon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -28,12 +29,17 @@ type addonSecretPropagationReconciler struct {
 func (r *addonSecretPropagationReconciler) Reconcile(ctx context.Context, addon *addonsv1alpha1.Addon) (ctrl.Result, error) {
 	if addon.Spec.SecretPropagation == nil ||
 		len(addon.Spec.SecretPropagation.Secrets) == 0 {
+		err := r.cleanupUnknownSecrets(ctx, map[client.ObjectKey]struct{}{}, addon)
+		if err != nil {
+			err = errors.Join(err, controllers.ErrCleanupUnknownSecrets)
+		}
 		// just ensure all propagated secrets are gone
-		return ctrl.Result{}, r.cleanupUnknownSecrets(ctx, map[client.ObjectKey]struct{}{}, addon)
+		return ctrl.Result{}, err
 	}
 
 	destinationSecretsWithoutNamespace, result, err := r.getDestinationSecretsWithoutNamespace(ctx, addon)
 	if err != nil {
+		err := errors.Join(err, controllers.ErrGetDestinationSecretsWithoutNamespace)
 		return ctrl.Result{}, err
 	}
 	if !result.IsZero() {
@@ -42,11 +48,13 @@ func (r *addonSecretPropagationReconciler) Reconcile(ctx context.Context, addon 
 
 	knownSecrets, err := r.reconcileSecretsInAddonNamespaces(ctx, destinationSecretsWithoutNamespace, addon)
 	if err != nil {
+		err := errors.Join(err, controllers.ErrEnsureSecretsInAddonNamespaces)
 		return ctrl.Result{}, err
 	}
 
 	if err := r.cleanupUnknownSecrets(ctx, knownSecrets, addon); err != nil {
-		return ctrl.Result{}, fmt.Errorf("propagated secret cleanup: %w", err)
+		err := errors.Join(err, controllers.ErrCleanupUnknownSecrets)
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
@@ -105,10 +113,10 @@ func (r *addonSecretPropagationReconciler) getReferencedSecret(
 	referencedSecret := &corev1.Secret{}
 
 	err := r.cachedClient.Get(ctx, secretKey, referencedSecret)
-	if errors.IsNotFound(err) {
+	if apiErrors.IsNotFound(err) {
 		// the referenced secret might not be labeled correctly for the cache to pick up,
 		// fallback to a uncached read to discover.
-		if err := r.uncachedClient.Get(ctx, secretKey, referencedSecret); errors.IsNotFound(err) {
+		if err := r.uncachedClient.Get(ctx, secretKey, referencedSecret); apiErrors.IsNotFound(err) {
 			// Secret does not exist for sure, break and keep retrying later.
 			reportPendingStatus(addon, addonsv1alpha1.AddonReasonMissingSecretForPropagation, err.Error())
 			return nil, ctrl.Result{RequeueAfter: defaultRetryAfterTime}, nil
@@ -184,8 +192,8 @@ func reconcileSecret(
 	ctx context.Context, c client.Client, desiredSecret *corev1.Secret) error {
 	actualSecret := &corev1.Secret{}
 	err := c.Get(ctx, client.ObjectKeyFromObject(desiredSecret), actualSecret)
-	if errors.IsNotFound(err) {
-		if err := c.Create(ctx, desiredSecret); err != nil && !errors.IsAlreadyExists(err) {
+	if apiErrors.IsNotFound(err) {
+		if err := c.Create(ctx, desiredSecret); err != nil && !apiErrors.IsAlreadyExists(err) {
 			return fmt.Errorf("creating secret: %w", err)
 		}
 		return nil

--- a/internal/controllers/addon/status_reporting.go
+++ b/internal/controllers/addon/status_reporting.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
+	"github.com/openshift/addon-operator/internal/metrics"
 	"github.com/openshift/addon-operator/internal/ocm"
 )
 
@@ -63,10 +64,10 @@ func (r *AddonReconciler) statusReportingRequired(addon *addonsv1alpha1.Addon) b
 }
 
 func (r *AddonReconciler) recordAddonServiceRequestDuration(reqFunc func()) {
-	if r.Recorder != nil {
+	if metrics.IsMetricsRecorderInitialized() {
 		timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
 			us := v * 1000000 // convert to microseconds
-			r.Recorder.RecordAddonServiceAPIRequests(us)
+			metrics.MetricsRecorder().RecordAddonServiceAPIRequests(us)
 		}))
 		defer timer.ObserveDuration()
 	}

--- a/internal/controllers/addon/status_reporting_test.go
+++ b/internal/controllers/addon/status_reporting_test.go
@@ -104,7 +104,6 @@ func TestHandleAddonStatusReporting(t *testing.T) {
 		r := &AddonReconciler{
 			Client:    client,
 			ocmClient: ocmClient,
-			Recorder:  recorder,
 		}
 		r.statusReportingEnabled = true
 		addon := &addonsv1alpha1.Addon{
@@ -162,7 +161,6 @@ func TestHandleAddonStatusReporting(t *testing.T) {
 		r := &AddonReconciler{
 			Client:    client,
 			ocmClient: ocmClient,
-			Recorder:  recorder,
 		}
 		r.statusReportingEnabled = true
 		addon := &addonsv1alpha1.Addon{
@@ -231,7 +229,6 @@ func TestHandleAddonStatusReporting(t *testing.T) {
 		r := &AddonReconciler{
 			Client:    client,
 			ocmClient: ocmClient,
-			Recorder:  recorder,
 		}
 		r.statusReportingEnabled = true
 		addon := &addonsv1alpha1.Addon{
@@ -299,7 +296,6 @@ func TestHandleAddonStatusReporting(t *testing.T) {
 		r := &AddonReconciler{
 			Client:    client,
 			ocmClient: ocmClient,
-			Recorder:  recorder,
 		}
 		r.statusReportingEnabled = true
 		addon := &addonsv1alpha1.Addon{

--- a/internal/controllers/addon/upgradepolicy_status.go
+++ b/internal/controllers/addon/upgradepolicy_status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/openshift/addon-operator/internal/metrics"
 	"github.com/openshift/addon-operator/internal/ocm"
 
 	"github.com/go-logr/logr"
@@ -182,11 +183,11 @@ func (r *AddonReconciler) handleGetUpgradePolicyState(ctx context.Context,
 }
 
 func (r *AddonReconciler) recordOCMRequestDuration(reqFunc func()) {
-	if r.Recorder != nil {
+	if metrics.IsMetricsRecorderInitialized() {
 		// TODO: do not count metrics when API returns 5XX response
 		timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
 			us := v * 1000000 // convert to microseconds
-			r.Recorder.RecordOCMAPIRequests(us)
+			metrics.MetricsRecorder().RecordOCMAPIRequests(us)
 		}))
 		defer timer.ObserveDuration()
 	}

--- a/internal/controllers/addon/upgradepolicy_status_test.go
+++ b/internal/controllers/addon/upgradepolicy_status_test.go
@@ -83,7 +83,6 @@ func TestAddonReconciler_handleUpgradePolicyStatusReporting(t *testing.T) {
 		r := &AddonReconciler{
 			Client:    client,
 			ocmClient: ocmClient,
-			Recorder:  recorder,
 		}
 
 		var Version = "1.0.0"
@@ -198,7 +197,6 @@ func TestAddonReconciler_handleUpgradePolicyStatusReporting(t *testing.T) {
 		r := &AddonReconciler{
 			Client:    client,
 			ocmClient: ocmClient,
-			Recorder:  recorder,
 		}
 		log := testutil.NewLogger(t)
 		addon := &addonsv1alpha1.Addon{

--- a/internal/controllers/addonoperator/utils.go
+++ b/internal/controllers/addonoperator/utils.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
+	"github.com/openshift/addon-operator/internal/metrics"
 	"github.com/openshift/addon-operator/internal/ocm"
 )
 
@@ -31,8 +32,8 @@ func (r *AddonOperatorReconciler) handleAddonOperatorCreation(
 			Name: addonsv1alpha1.DefaultAddonOperatorName,
 		},
 	}
-	if r.Recorder != nil {
-		r.Recorder.SetAddonOperatorPaused(false)
+	if metrics.IsMetricsRecorderInitialized() {
+		metrics.MetricsRecorder().SetAddonOperatorPaused(false)
 	}
 	log.Info("creating default AddonOperator object")
 	err := r.Create(ctx, defaultAddonOperator)

--- a/internal/controllers/errors.go
+++ b/internal/controllers/errors.go
@@ -1,9 +1,43 @@
 package controllers
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	// This error is returned when a reconciled child object already
 	// exists and is not owned by the current controller/addon
 	ErrNotOwnedByUs = errors.New("object is not owned by us")
+
+	// Reconciler/Controller reconcile errors
+	ErrAddonNotFound                         = errors.New("failed to get addon")
+	ErrAddFinalizer                          = errors.New("failed to add finalizer")
+	ErrNotifyAddon                           = errors.New("failed to notify addon")
+	ErrAckReceivedFromAddon                  = errors.New("failed to receive ack from addon")
+	ErrEnsureCreateAddonInstance             = errors.New("failed to ensure creation of addoninstance")
+	ErrEnsureCreateServiceMonitor            = errors.New("failed to ensure servicemonitor")
+	ErrEnsureDeleteUnwantedServiceMonitor    = errors.New("failed to ensure deletion of unwanted servicemonitor")
+	ErrEnsureCreateMonitoringStack           = errors.New("failed to ensure creation of monitoring stack")
+	ErrEnsureCreateNamespaces                = errors.New("failed to ensure creation of namespaces")
+	ErrEnsureDeleteNamespaces                = errors.New("failed to ensure deletion of namespaces")
+	ErrEnsureOperatorGroup                   = errors.New("failed to ensure operatorgroup")
+	ErrEnsureNetworkPolicy                   = errors.New("failed to ensure networkpolicy for catalgosources")
+	ErrEnsureCatalogSource                   = errors.New("failed to ensure catalogsource")
+	ErrEnsureAdditionalCatalogSource         = errors.New("failed to ensure additional catalogsource")
+	ErrEnsureSubscription                    = errors.New("failed to ensure subscription")
+	ErrObserveCurrentCSV                     = errors.New("failed to observe current CSV")
+	ErrEnsureClusterObjectTemplateTornDown   = errors.New("failed to ensure tearing down of clusterobjecttemplate")
+	ErrEnsureClusterObjectTemplate           = errors.New("failed to ensure clusterobjecttemplate")
+	ErrCleanupUnknownSecrets                 = errors.New("failed to cleanup unknown secrets")
+	ErrGetDestinationSecretsWithoutNamespace = errors.New("failed to get destination secrets without namespace")
+	ErrEnsureSecretsInAddonNamespaces        = errors.New("failed to ensure serects in addon namespaces")
+	ErrCleanupUnkownSecrets                  = errors.New("failed to cleanup unknown secrets")
+	ErrAddonInstanceNotFound                 = errors.New("failed to of get addoninstance")
+	ErrUpdatingAddonInstanceStatus           = errors.New("failed to update addoninstance status")
+	ErrExecuteAddonInstanceReconcilePhase    = errors.New("failed to execute addoninstance reconcile phase")
+	ErrDefaultAddonOperatorNotFound          = errors.New("failed to find default addonoperators")
+	ErrCreateAddonOperator                   = errors.New("failed to create addonoperator")
+	ErrAddonOperatorHandleGlobalPause        = errors.New("failed to handle addonoperator global pause")
+	ErrCreateOCMClient                       = errors.New("failed to create OCM client")
+	ErrReportAddonOperatorReadinessStatus    = errors.New("failed to report addonoperator readiness status")
 )


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
This PR implements the collection of controller/reconciler errors as prometheus metrics. This is necessary to enhance the observability of ADO, and particularly to enable the following:

1. Analysis of reconcile errors overtime
2. Alerting on repeated (anomalous) reconcile errors. This promotes alerting as early as possible before multiple errors that are coming from services other than ADO converge to a known error/status that can likely impact a customer. To be more specific, errors that are reported in CR status (e.g. Addon) are not an instrumentation feature, rather it's part of the domain-specific purpose of a controller (e.g. ADO), therefore they are not necessarily for effective alerting.

**Implementation Overview**

1. Modified the metrics Recorder to be a singleton, please advise a better singleton utility if there are any. This simplifies metrics collection as its purpose is for instrumentation, therefore it should be conveniently accessible from areas that need metrics to be collected. This also ensures that there is only one metrics collector for ADO, promoting simpler management of this object.

2. Reconciler errors that happen in their `Reconcile` methods are represented as `ReconcileError` and are collected in a `prometheus.GaugeVec`.  Note that these reconcile errors are ADO-specific and should not be equated directly with controller-runtime-level reconcile errors, the latter is designed to be agnostic to specific controller errors (see controller runtime metrics). 

3. So far, there are 2 cases for these reconcile errors. The first case is that a reconcile error is caused at the top-level controller, and the second case is when it's caused by an error in a subreconciler reconcile method. However, **these errors are all collected at the top-level controller reconcile method for simplicity** (see `controller.go`). The first case is straightforward to collect, the second case requires the subreconcilers to report their specific errors by wrapping it with the original error that caused it. This is done by simply using the `errors.Join` utility. These subreconciler errors can then be unwrapped automatically by using a ReconcileError with a subreconciler option.

4. Error defs are created as well. I'm not so sure about the best practice for Go with respect to creating error defs. I want to just use an error ID (e.g. ErrMyErr = "ErrMyErr") instead of a phrase (e.g. "my error") so that it is less prone to typo, and fewer characters to compare in prometheus queries. However, doing this will also reduce usability for these error metrics. Please advise.

5. As far as I know, prometheus clients are required to be thread-safe as mentioned in the prometheus documentation. The changes in these PR do not introduce a shared object that needs to be synchronized by multiple controller execution threads, therefore it should be thread-safe assuming I'm right about prometheus golang client thread-safety.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #MTSRE-1521_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Ran `make test-unit` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR
- [x] Squashed your commits
