### PR TITLE
MTSRE-1521: Collect metrics for reconcile errors

### DIFF
--- a/cmd/addon-operator-manager/main.go
+++ b/cmd/addon-operator-manager/main.go
@@ -129,6 +129,7 @@ func initReconcilers(mgr ctrl.Manager,
 				aictrl.WithLog{Log: addonInstancePhaseLog.WithName("checkHeartbeat")},
 			),
 		},
+		aictrl.WithRecorder{Recorder: recorder},
 	)
 
 	if err := addonInstanceCtrl.SetupWithManager(mgr); err != nil {

--- a/internal/controllers/addon/addon_deletion_reconciler.go
+++ b/internal/controllers/addon/addon_deletion_reconciler.go
@@ -9,6 +9,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
+	"github.com/openshift/addon-operator/internal/controllers"
+	"github.com/openshift/addon-operator/internal/metrics"
 )
 
 const (
@@ -34,6 +36,7 @@ func (c defaultClock) Now() time.Time {
 type addonDeletionReconciler struct {
 	clock    clock
 	handlers []addonDeletionHandler
+	recorder *metrics.Recorder
 }
 
 func (r *addonDeletionReconciler) Reconcile(ctx context.Context, addon *addonsv1alpha1.Addon) (ctrl.Result, error) {
@@ -52,13 +55,17 @@ func (r *addonDeletionReconciler) Reconcile(ctx context.Context, addon *addonsv1
 	// We set ReadyToBeDeleted=false status condition in response to the delete signal received from OCM.
 	reportAddonReadyToBeDeletedStatus(addon, metav1.ConditionFalse)
 
+	reconErr := metrics.NewReconcileError("addon", r.recorder, true)
+
 	for _, handler := range r.handlers {
 		if err := handler.NotifyAddon(ctx, addon); err != nil {
+			err = reconErr.Join(err, controllers.ErrNotifyAddon)
 			return ctrl.Result{}, err
 		}
 		// If ack is received from the underlying addon, we report ReadyToBeDeleted = true.
 		ackReceived, err := handler.AckReceivedFromAddon(ctx, addon)
 		if err != nil {
+			err = reconErr.Join(err, controllers.ErrAckReceivedFromAddon)
 			return ctrl.Result{}, err
 		}
 		if ackReceived {

--- a/internal/controllers/addon/addon_instance_reconciler.go
+++ b/internal/controllers/addon/addon_instance_reconciler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -15,20 +15,24 @@ import (
 
 	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
 	"github.com/openshift/addon-operator/internal/controllers"
+	"github.com/openshift/addon-operator/internal/metrics"
 )
 
 const ADDON_INSTANCE_RECONCILER_NAME = "addonInstanceReconciler"
 
 type addonInstanceReconciler struct {
-	client client.Client
-	scheme *runtime.Scheme
+	client   client.Client
+	scheme   *runtime.Scheme
+	recorder *metrics.Recorder
 }
 
 func (r *addonInstanceReconciler) Reconcile(ctx context.Context,
 	addon *addonsv1alpha1.Addon) (reconcile.Result, error) {
+	reconErr := metrics.NewReconcileError("addon", r.recorder, true)
 	// Ensure the creation of the corresponding AddonInstance in .spec.install.olmOwnNamespace/.spec.install.olmAllNamespaces namespace
 	if err := r.ensureAddonInstance(ctx, addon); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to ensure the creation of addoninstance: %w", err)
+		err = reconErr.Join(err, controllers.ErrEnsureCreateAddonInstance)
+		return ctrl.Result{}, err
 	}
 	return reconcile.Result{}, nil
 }
@@ -73,7 +77,7 @@ func (r *addonInstanceReconciler) reconcileAddonInstance(
 	ctx context.Context, desiredAddonInstance *addonsv1alpha1.AddonInstance) error {
 	currentAddonInstance := &addonsv1alpha1.AddonInstance{}
 	err := r.client.Get(ctx, client.ObjectKeyFromObject(desiredAddonInstance), currentAddonInstance)
-	if errors.IsNotFound(err) {
+	if apiErrors.IsNotFound(err) {
 		return r.client.Create(ctx, desiredAddonInstance)
 	}
 	if err != nil {

--- a/internal/controllers/addon/addon_reconciler_options.go
+++ b/internal/controllers/addon/addon_reconciler_options.go
@@ -41,6 +41,7 @@ func (w WithPackageOperatorReconciler) ApplyToAddonReconciler(config *AddonRecon
 		Scheme:         w.Scheme,
 		ClusterID:      config.ClusterExternalID,
 		OcmClusterInfo: config.GetOCMClusterInfo,
+		recorder:       config.Recorder,
 	}
 	config.subReconcilers = append(config.subReconcilers, poReconciler)
 }

--- a/internal/controllers/addon/controller.go
+++ b/internal/controllers/addon/controller.go
@@ -97,11 +97,13 @@ func NewAddonReconciler(
 					&legacyDeletionHandler{client: client, uncachedClient: uncachedClient},
 					&addonInstanceDeletionHandler{client: client},
 				},
+				recorder: recorder,
 			},
 			// Step 2: Reconcile Namespace
 			&namespaceReconciler{
-				client: client,
-				scheme: scheme,
+				client:   client,
+				scheme:   scheme,
+				recorder: recorder,
 			},
 			// Step 3: Reconcile Addon pull secrets
 			&addonSecretPropagationReconciler{
@@ -109,11 +111,13 @@ func NewAddonReconciler(
 				uncachedClient:         uncachedClient,
 				scheme:                 scheme,
 				addonOperatorNamespace: addonOperatorNamespace,
+				recorder:               recorder,
 			},
 			// Step 4: Reconcile AddonInstance object
 			&addonInstanceReconciler{
-				client: client,
-				scheme: scheme,
+				client:   client,
+				scheme:   scheme,
+				recorder: recorder,
 			},
 			// Step 5: Reconcile OLM objects
 			&olmReconciler{
@@ -121,11 +125,13 @@ func NewAddonReconciler(
 				uncachedClient:          uncachedClient,
 				scheme:                  scheme,
 				operatorResourceHandler: operatorResourceHandler,
+				recorder:                recorder,
 			},
 			// Step 6: Reconcile Monitoring Federation
 			&monitoringFederationReconciler{
-				client: client,
-				scheme: scheme,
+				client:   client,
+				scheme:   scheme,
+				recorder: recorder,
 			},
 		},
 	}
@@ -273,9 +279,11 @@ func (r *AddonReconciler) Reconcile(
 ) (ctrl.Result, error) {
 	logger := r.Log.WithValues("addon", req.NamespacedName.String())
 	ctx = controllers.ContextWithLogger(ctx, logger)
+	reconErr := metrics.NewReconcileError("addon", r.Recorder, false)
 
 	addon := &addonsv1alpha1.Addon{}
 	if err := r.Get(ctx, req.NamespacedName, addon); err != nil {
+		reconErr.Report(controllers.ErrGetAddon)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -286,6 +294,10 @@ func (r *AddonReconciler) Reconcile(
 		r.Recorder.RecordAddonMetrics(addon)
 	}
 	errors := r.syncWithExternalAPIs(ctx, logger, addon)
+
+	if errors.ErrorOrNil() != nil {
+		reconErr.Report(controllers.ErrSyncWithExternalAPIs)
+	}
 
 	// append reconcilerErr
 	errors = multierror.Append(errors, reconcileErr)
@@ -322,6 +334,8 @@ func (r *AddonReconciler) reconcile(ctx context.Context, addon *addonsv1alpha1.A
 	log logr.Logger,
 ) (ctrl.Result, error) {
 	ctx = controllers.ContextWithLogger(ctx, log)
+	reconErr := metrics.NewReconcileError("addon", r.Recorder, false)
+	subReconErr := metrics.NewReconcileError("addon", r.Recorder, true)
 	// Handle addon deletion before checking for pause condition.
 	// This allows even paused addons to be deleted.
 	if !addon.DeletionTimestamp.IsZero() {
@@ -362,6 +376,7 @@ func (r *AddonReconciler) reconcile(ctx context.Context, addon *addonsv1alpha1.A
 	if !controllerutil.ContainsFinalizer(addon, cacheFinalizer) {
 		controllerutil.AddFinalizer(addon, cacheFinalizer)
 		if err := r.Update(ctx, addon); err != nil {
+			reconErr.Report(controllers.ErrUpdateAddon)
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
 	}
@@ -369,6 +384,7 @@ func (r *AddonReconciler) reconcile(ctx context.Context, addon *addonsv1alpha1.A
 	// Run each sub reconciler serially
 	for _, reconciler := range r.subReconcilers {
 		if result, err := reconciler.Reconcile(ctx, addon); err != nil {
+			subReconErr.Report(err)
 			return ctrl.Result{}, fmt.Errorf("%s : failed to reconcile : %w", reconciler.Name(), err)
 		} else if !result.IsZero() {
 			return result, nil

--- a/internal/controllers/addon/controller_test.go
+++ b/internal/controllers/addon/controller_test.go
@@ -14,7 +14,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	promTestUtil "github.com/prometheus/client_golang/prometheus/testutil"
+
 	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
+	"github.com/openshift/addon-operator/internal/controllers"
+	"github.com/openshift/addon-operator/internal/metrics"
 	"github.com/openshift/addon-operator/internal/ocm"
 	"github.com/openshift/addon-operator/internal/ocm/ocmtest"
 	"github.com/openshift/addon-operator/internal/testutil"
@@ -26,7 +30,10 @@ type reconcileErrorTestCase struct {
 	statusUpdateErrPresent    bool
 }
 
-var _ addonReconciler = (*mockSubReconciler)(nil)
+var (
+	_                   addonReconciler = (*mockSubReconciler)(nil)
+	errMockSubReconcile                 = errors.New("failed to reconcile")
+)
 
 type mockSubReconciler struct {
 	returnErr bool
@@ -38,7 +45,7 @@ func (m *mockSubReconciler) Name() string {
 
 func (m *mockSubReconciler) Reconcile(ctx context.Context, addon *addonsv1alpha1.Addon) (ctrl.Result, error) {
 	if m.returnErr {
-		return ctrl.Result{}, errors.New("failed to reconcile")
+		return ctrl.Result{}, errMockSubReconcile
 	}
 	return ctrl.Result{}, nil
 }
@@ -86,13 +93,17 @@ func TestReconcileErrorHandling(t *testing.T) {
 			statusUpdateErrPresent:    true,
 		},
 	}
-	for _, testCase := range testCases {
+
+	for idx, testCase := range testCases {
 		client := testutil.NewClient()
 		ocmClient := ocmtest.NewClient()
+		recorder := metrics.NewRecorder(true, fmt.Sprintf("clusterID-%v", idx))
+
 		r := AddonReconciler{
 			Client:         client,
 			ocmClient:      ocmClient,
 			Log:            logr.Discard(),
+			Recorder:       recorder,
 			subReconcilers: []addonReconciler{},
 		}
 
@@ -135,6 +146,32 @@ func TestReconcileErrorHandling(t *testing.T) {
 			multiErr, ok := err.(*multierror.Error) //nolint
 			assert.True(t, ok, "expected multi error")
 			assert.Equal(t, expectedNumErrors(testCase), multiErr.Len())
+		}
+
+		metric := recorder.GetReconcileErrorMetric()
+		assert.NotNil(t, metric)
+
+		if testCase.externalAPISyncErrPresent {
+			// Ensure sync error during reconcile was collected as a metric
+			controllerMetricVal := promTestUtil.ToFloat64(
+				metric.WithLabelValues(
+					"addon",
+					controllers.ErrSyncWithExternalAPIs.Error(),
+					addon.Name,
+				),
+			)
+			assert.True(t, controllerMetricVal > 0)
+		}
+		if testCase.reconcilerErrPresent {
+			// Ensure reconcile error was collected as a metric
+			controllerMetricVal := promTestUtil.ToFloat64(
+				metric.WithLabelValues(
+					"addon",
+					errMockSubReconcile.Error(),
+					addon.Name,
+				),
+			)
+			assert.True(t, controllerMetricVal > 0)
 		}
 	}
 }

--- a/internal/controllers/addon/monitoring_federation_reconciler.go
+++ b/internal/controllers/addon/monitoring_federation_reconciler.go
@@ -19,18 +19,21 @@ import (
 
 	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
 	"github.com/openshift/addon-operator/internal/controllers"
+	"github.com/openshift/addon-operator/internal/metrics"
 )
 
 const MONITORING_FEDERATION_RECONCILER_NAME = "monitoringFederationReconciler"
 
 type monitoringFederationReconciler struct {
-	client client.Client
-	scheme *runtime.Scheme
+	client   client.Client
+	scheme   *runtime.Scheme
+	recorder *metrics.Recorder
 }
 
 func (r *monitoringFederationReconciler) Reconcile(ctx context.Context,
 	addon *addonsv1alpha1.Addon) (ctrl.Result, error) {
 	log := controllers.LoggerFromContext(ctx)
+	reconErr := metrics.NewReconcileError("addon", r.recorder, true)
 
 	// Possibly ensure monitoring federation
 	// Normally this would be configured before the addon workload is installed
@@ -44,14 +47,19 @@ func (r *monitoringFederationReconciler) Reconcile(ctx context.Context,
 
 		return ctrl.Result{}, nil
 	} else if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to ensure ServiceMonitor: %w", err)
+		err = reconErr.Join(err, controllers.ErrEnsureCreateServiceMonitor)
+		return ctrl.Result{}, err
 	} else if !result.IsZero() {
 		return result, nil
 	}
 
 	// Remove possibly unwanted monitoring federation
 	if err := r.ensureDeletionOfUnwantedMonitoringFederation(ctx, addon); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to ensure deletion of unwanted ServiceMonitors: %w", err)
+		err = reconErr.Join(
+			err,
+			controllers.ErrEnsureDeleteServiceMonitor,
+		)
+		return ctrl.Result{}, err
 	}
 	return reconcile.Result{}, nil
 }

--- a/internal/controllers/addon/namespace_reconciler.go
+++ b/internal/controllers/addon/namespace_reconciler.go
@@ -16,13 +16,15 @@ import (
 
 	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
 	"github.com/openshift/addon-operator/internal/controllers"
+	"github.com/openshift/addon-operator/internal/metrics"
 )
 
 const NAMESPACE_RECONCILER_NAME = "namespaceReconciler"
 
 type namespaceReconciler struct {
-	client client.Client
-	scheme *runtime.Scheme
+	client   client.Client
+	scheme   *runtime.Scheme
+	recorder *metrics.Recorder
 }
 
 func (r *namespaceReconciler) Reconcile(ctx context.Context,

--- a/internal/controllers/addon/package_operator_reconciler.go
+++ b/internal/controllers/addon/package_operator_reconciler.go
@@ -13,6 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
+	"github.com/openshift/addon-operator/internal/controllers"
+	"github.com/openshift/addon-operator/internal/metrics"
 
 	pkov1alpha1 "package-operator.run/apis/core/v1alpha1"
 )
@@ -60,22 +62,34 @@ type PackageOperatorReconciler struct {
 	Scheme         *runtime.Scheme
 	ClusterID      string
 	OcmClusterInfo OcmClusterInfoGetter
+	recorder       *metrics.Recorder
 }
 
 func (r *PackageOperatorReconciler) Name() string { return packageOperatorName }
 
 func (r *PackageOperatorReconciler) Reconcile(ctx context.Context, addon *addonsv1alpha1.Addon) (ctrl.Result, error) {
+	reconErr := metrics.NewReconcileError("addon", r.recorder, true)
 	if addon.Spec.AddonPackageOperator == nil {
-		return ctrl.Result{}, r.ensureClusterObjectTemplateTornDown(ctx, addon)
+		err := r.ensureClusterObjectTemplateTornDown(ctx, addon)
+		if err != nil {
+			err = reconErr.Join(err, controllers.ErrEnsureDeleteClusterObjectTemplate)
+		}
+		return ctrl.Result{}, err
 	}
+
 	return r.reconcileClusterObjectTemplate(ctx, addon)
 }
 
 func (r *PackageOperatorReconciler) reconcileClusterObjectTemplate(ctx context.Context, addon *addonsv1alpha1.Addon) (ctrl.Result, error) {
 	addonDestNamespace := extractDestinationNamespace(addon)
+	reconErr := metrics.NewReconcileError("addon", r.recorder, true)
 
 	if len(addonDestNamespace) < 1 {
-		return ctrl.Result{}, fmt.Errorf("no destination namespace configured in addon %s", addon.Name)
+		err := reconErr.Join(
+			fmt.Errorf("no destination namespace configured in addon %s", addon.Name),
+			controllers.ErrReconcileClusterObjectTemplate,
+		)
+		return ctrl.Result{}, err
 	}
 
 	ocmClusterInfo := r.OcmClusterInfo()
@@ -156,23 +170,40 @@ func (r *PackageOperatorReconciler) reconcileClusterObjectTemplate(ctx context.C
 	}
 
 	if err := controllerutil.SetControllerReference(addon, clusterObjectTemplate, r.Scheme); err != nil {
-		return ctrl.Result{}, fmt.Errorf("setting owner reference: %w", err)
+		newErr := reconErr.Join(
+			fmt.Errorf("setting owner reference: %w", err),
+			controllers.ErrReconcileClusterObjectTemplate,
+		)
+		return ctrl.Result{}, newErr
 	}
 
 	existingClusterObjectTemplate, err := r.getExistingClusterObjectTemplate(ctx, addon)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			if err := r.Client.Create(ctx, clusterObjectTemplate); err != nil {
-				return ctrl.Result{}, fmt.Errorf("creating ClusterObjectTemplate object: %w", err)
+				newErr := reconErr.Join(
+					fmt.Errorf("creating ClusterObjectTemplate object: %w", err),
+					controllers.ErrReconcileClusterObjectTemplate,
+				)
+
+				return ctrl.Result{}, newErr
 			}
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, fmt.Errorf("getting ClusterObjectTemplate object: %w", err)
+		newErr := reconErr.Join(
+			fmt.Errorf("getting ClusterObjectTemplate object: %w", err),
+			controllers.ErrReconcileClusterObjectTemplate,
+		)
+		return ctrl.Result{}, newErr
 	}
 
 	clusterObjectTemplate.ResourceVersion = existingClusterObjectTemplate.ResourceVersion
 	if err := r.Client.Update(ctx, clusterObjectTemplate); err != nil {
-		return ctrl.Result{}, fmt.Errorf("updating ClusterObjectTemplate object: %w", err)
+		newErr := reconErr.Join(
+			fmt.Errorf("updating ClusterObjectTemplate object: %w", err),
+			controllers.ErrReconcileClusterObjectTemplate,
+		)
+		return ctrl.Result{}, newErr
 	}
 	r.updateAddonStatus(addon, existingClusterObjectTemplate)
 

--- a/internal/controllers/addon/secret_reconciler.go
+++ b/internal/controllers/addon/secret_reconciler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -14,6 +14,7 @@ import (
 
 	addonsv1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
 	"github.com/openshift/addon-operator/internal/controllers"
+	"github.com/openshift/addon-operator/internal/metrics"
 )
 
 const SECRET_RECONCILER_NAME = "secretPropogationReconciler"
@@ -23,17 +24,24 @@ type addonSecretPropagationReconciler struct {
 	cachedClient, uncachedClient client.Client
 	scheme                       *runtime.Scheme
 	addonOperatorNamespace       string
+	recorder                     *metrics.Recorder
 }
 
 func (r *addonSecretPropagationReconciler) Reconcile(ctx context.Context, addon *addonsv1alpha1.Addon) (ctrl.Result, error) {
+	reconErr := metrics.NewReconcileError("addon", r.recorder, true)
 	if addon.Spec.SecretPropagation == nil ||
 		len(addon.Spec.SecretPropagation.Secrets) == 0 {
+		var err error
+		if err = r.cleanupUnknownSecrets(ctx, map[client.ObjectKey]struct{}{}, addon); err != nil {
+			err = reconErr.Join(err, controllers.ErrCleanupUnknownSecrets)
+		}
 		// just ensure all propagated secrets are gone
-		return ctrl.Result{}, r.cleanupUnknownSecrets(ctx, map[client.ObjectKey]struct{}{}, addon)
+		return ctrl.Result{}, err
 	}
 
 	destinationSecretsWithoutNamespace, result, err := r.getDestinationSecretsWithoutNamespace(ctx, addon)
 	if err != nil {
+		err := reconErr.Join(err, controllers.ErrGetDestinationSecretsWithoutNamespace)
 		return ctrl.Result{}, err
 	}
 	if !result.IsZero() {
@@ -42,11 +50,13 @@ func (r *addonSecretPropagationReconciler) Reconcile(ctx context.Context, addon 
 
 	knownSecrets, err := r.reconcileSecretsInAddonNamespaces(ctx, destinationSecretsWithoutNamespace, addon)
 	if err != nil {
+		err := reconErr.Join(err, controllers.ErrReconcileSecretsInAddonNamespaces)
 		return ctrl.Result{}, err
 	}
 
 	if err := r.cleanupUnknownSecrets(ctx, knownSecrets, addon); err != nil {
-		return ctrl.Result{}, fmt.Errorf("propagated secret cleanup: %w", err)
+		err := reconErr.Join(err, controllers.ErrCleanupUnknownSecrets)
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
@@ -105,10 +115,10 @@ func (r *addonSecretPropagationReconciler) getReferencedSecret(
 	referencedSecret := &corev1.Secret{}
 
 	err := r.cachedClient.Get(ctx, secretKey, referencedSecret)
-	if errors.IsNotFound(err) {
+	if apiErrors.IsNotFound(err) {
 		// the referenced secret might not be labeled correctly for the cache to pick up,
 		// fallback to a uncached read to discover.
-		if err := r.uncachedClient.Get(ctx, secretKey, referencedSecret); errors.IsNotFound(err) {
+		if err := r.uncachedClient.Get(ctx, secretKey, referencedSecret); apiErrors.IsNotFound(err) {
 			// Secret does not exist for sure, break and keep retrying later.
 			reportPendingStatus(addon, addonsv1alpha1.AddonReasonMissingSecretForPropagation, err.Error())
 			return nil, ctrl.Result{RequeueAfter: defaultRetryAfterTime}, nil
@@ -184,8 +194,8 @@ func reconcileSecret(
 	ctx context.Context, c client.Client, desiredSecret *corev1.Secret) error {
 	actualSecret := &corev1.Secret{}
 	err := c.Get(ctx, client.ObjectKeyFromObject(desiredSecret), actualSecret)
-	if errors.IsNotFound(err) {
-		if err := c.Create(ctx, desiredSecret); err != nil && !errors.IsAlreadyExists(err) {
+	if apiErrors.IsNotFound(err) {
+		if err := c.Create(ctx, desiredSecret); err != nil && !apiErrors.IsAlreadyExists(err) {
 			return fmt.Errorf("creating secret: %w", err)
 		}
 		return nil

--- a/internal/controllers/addoninstance/controller.go
+++ b/internal/controllers/addoninstance/controller.go
@@ -11,7 +11,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	av1alpha1 "github.com/openshift/addon-operator/apis/addons/v1alpha1"
+	"github.com/openshift/addon-operator/internal/controllers"
 	"github.com/openshift/addon-operator/internal/controllers/addoninstance/internal/phase"
+	"github.com/openshift/addon-operator/internal/metrics"
 )
 
 func NewController(c client.Client, opts ...ControllerOption) *Controller {
@@ -42,9 +44,10 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		"namespace", req.Namespace,
 		"name", req.Name,
 	)
-
+	reconErr := metrics.NewReconcileError("addoninstance", c.cfg.Recorder, true)
 	instance, err := c.client.Get(ctx, req.Name, req.Namespace)
 	if err != nil {
+		reconErr.Report(controllers.ErrGetAddonInstance)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -52,6 +55,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Info("updating status conditions")
 
 		if err := c.client.UpdateStatus(ctx, instance); err != nil {
+			reconErr.Report(controllers.ErrUpdateAddonInstanceStatus)
 			log.Error(err, "updating AddonInstance status")
 		}
 	}()
@@ -68,6 +72,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 
 		if err := res.Error(); err != nil {
+			reconErr.Report(controllers.ErrExecuteAddonInstanceReconcilePhase)
 			return ctrl.Result{}, fmt.Errorf("executing phase %q: %w", p, err)
 		}
 	}
@@ -81,6 +86,7 @@ type ControllerConfig struct {
 	Log             logr.Logger
 	PollingInterval time.Duration
 	SerialPhases    []Phase
+	Recorder        *metrics.Recorder
 }
 
 func (c *ControllerConfig) Option(opts ...ControllerOption) {

--- a/internal/controllers/addoninstance/controller.go
+++ b/internal/controllers/addoninstance/controller.go
@@ -47,7 +47,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	reconErr := metrics.NewReconcileError("addoninstance", c.cfg.Recorder, true)
 	instance, err := c.client.Get(ctx, req.Name, req.Namespace)
 	if err != nil {
-		reconErr.Report(controllers.ErrGetAddonInstance)
+		reconErr.Report(controllers.ErrGetAddonInstance, req.Name)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -55,7 +55,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Info("updating status conditions")
 
 		if err := c.client.UpdateStatus(ctx, instance); err != nil {
-			reconErr.Report(controllers.ErrUpdateAddonInstanceStatus)
+			reconErr.Report(controllers.ErrUpdateAddonInstanceStatus, req.Name)
 			log.Error(err, "updating AddonInstance status")
 		}
 	}()
@@ -72,7 +72,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 
 		if err := res.Error(); err != nil {
-			reconErr.Report(controllers.ErrExecuteAddonInstanceReconcilePhase)
+			reconErr.Report(controllers.ErrExecuteAddonInstanceReconcilePhase, req.Name)
 			return ctrl.Result{}, fmt.Errorf("executing phase %q: %w", p, err)
 		}
 	}

--- a/internal/controllers/addoninstance/options.go
+++ b/internal/controllers/addoninstance/options.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+
+	"github.com/openshift/addon-operator/internal/metrics"
 )
 
 type WithClock struct{ Clock Clock }
@@ -38,4 +40,13 @@ type WithThresholdMultiplier int64
 
 func (w WithThresholdMultiplier) ConfigurePhaseCheckHeartbeat(c *PhaseCheckHeartbeatConfig) {
 	c.ThresholdMultiplier = int64(w)
+}
+
+type WithRecorder struct {
+	Recorder *metrics.Recorder
+}
+
+// Configures the metrics recorder
+func (w WithRecorder) ConfigureController(c *ControllerConfig) {
+	c.Recorder = w.Recorder
 }

--- a/internal/controllers/addonoperator/controller.go
+++ b/internal/controllers/addonoperator/controller.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/addon-operator/internal/controllers"
 	"github.com/openshift/addon-operator/internal/metrics"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -81,12 +82,17 @@ func (r *AddonOperatorReconciler) Reconcile(
 				addonOperator.Status.Conditions, addonsv1alpha1.AddonOperatorPaused))
 		}
 	}()
+
+	reconErr := metrics.NewReconcileError("addonoperator", r.Recorder, false)
+
 	// Create default AddonOperator object if it doesn't exist
 	if apierrors.IsNotFound(err) {
 		log.Info("default AddonOperator not found")
+		reconErr.Report(controllers.ErrGetDefaultAddonOperator, addonsv1alpha1.DefaultAddonOperatorName)
 		return ctrl.Result{}, r.handleAddonOperatorCreation(ctx, log)
 	}
 	if err != nil {
+		reconErr.Report(controllers.ErrGetDefaultAddonOperator, addonsv1alpha1.DefaultAddonOperatorName)
 		return ctrl.Result{}, err
 	}
 
@@ -98,10 +104,12 @@ func (r *AddonOperatorReconciler) Reconcile(
 	}
 
 	if err := r.handleGlobalPause(ctx, addonOperator); err != nil {
+		reconErr.Report(controllers.ErrAddonOperatorHandleGlobalPause, addonOperator.Name)
 		return ctrl.Result{}, fmt.Errorf("handling global pause: %w", err)
 	}
 
 	if err := r.handleOCMClient(ctx, log, addonOperator); err != nil {
+		reconErr.Report(controllers.ErrCreateOCMClient, addonOperator.Name)
 		return ctrl.Result{}, fmt.Errorf("handling OCM client: %w", err)
 	}
 
@@ -110,6 +118,7 @@ func (r *AddonOperatorReconciler) Reconcile(
 
 	err = r.reportAddonOperatorReadinessStatus(ctx, addonOperator)
 	if err != nil {
+		reconErr.Report(controllers.ErrReportAddonOperatorStatus, addonOperator.Name)
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: defaultAddonOperatorRequeueTime}, nil

--- a/internal/controllers/errors.go
+++ b/internal/controllers/errors.go
@@ -6,4 +6,65 @@ var (
 	// This error is returned when a reconciled child object already
 	// exists and is not owned by the current controller/addon
 	ErrNotOwnedByUs = errors.New("object is not owned by us")
+
+	// Failed to get an addon
+	ErrGetAddon = errors.New("err_get_addon")
+	// An error happened while syncing with external APIs
+	ErrSyncWithExternalAPIs = errors.New("err_sync_with_external_apis")
+	// Failed to update an addon
+	ErrUpdateAddon = errors.New("err_update_addon")
+	// Failed to notify addon
+	ErrNotifyAddon = errors.New("err_notify_addon")
+	// Failed to receive ack from addon
+	ErrAckReceivedFromAddon = errors.New("err_ack_received_from_addon")
+	// Failed to ensure creation of addoninstance
+	ErrEnsureCreateAddonInstance = errors.New("err_ensure_create_addoninstance")
+	// Failed to ensure creation of servicemonitor
+	ErrEnsureCreateServiceMonitor = errors.New("err_ensure_servicemonitor")
+	// Failed to ensure deletion of servicemonitor
+	ErrEnsureDeleteServiceMonitor = errors.New("err_ensure_delete_servicemonitor")
+	// Failed to ensure creation of monitoringstack
+	ErrEnsureCreateMonitoringStack = errors.New("err_ensure_create_monitoringstack")
+	// Failed to ensure creation of namespace
+	ErrEnsureCreateNamespace = errors.New("err_ensure_create_namespace")
+	// Failed to ensure deletion of namespace
+	ErrEnsureDeleteNamespace = errors.New("err_ensure_delete_namespace")
+	// Failed to ensure existence of operator group
+	ErrEnsureOperatorGroup = errors.New("err_ensure_operator_group")
+	// Failed to ensure existence of networkpolicy
+	ErrEnsureNetworkPolicy = errors.New("err_ensure_networkpolicy")
+	// Failed to ensure existence of catalogsource
+	ErrEnsureCatalogSource = errors.New("err_ensure_catalogsource")
+	// Failed to ensure existence of additional catalogsource
+	ErrEnsureAdditionalCatalogSource = errors.New("err_ensure_additional_catalogsource")
+	// An error happened while reconciling a subscription
+	ErrReconcileSubscription = errors.New("err_reconcile_subscription")
+	// An error happened while observing a CSV
+	ErrObserveCSV = errors.New("err_observe_csv")
+	// Failed to ensure deletion of clusterobjecttemplate
+	ErrEnsureDeleteClusterObjectTemplate = errors.New("err_ensure_delete_of_clusterobjecttemplate")
+	// An error happened while reconcileing clusterobjecttemplate
+	ErrReconcileClusterObjectTemplate = errors.New("err_reconcile_cluster_object_template")
+	// Failed to cleanup unknown secrets
+	ErrCleanupUnknownSecrets = errors.New("err_cleanup_unknown_secrets")
+	// Failed to get target/destination secrets that didn't have namespace
+	ErrGetDestinationSecretsWithoutNamespace = errors.New("err_get_destination_secrets_without_namespace")
+	// Failed reconcile secrets in addon namespaces
+	ErrReconcileSecretsInAddonNamespaces = errors.New("err_reconcile_secrets_in_addon_namespaces")
+	// Failed to get addoninstance
+	ErrGetAddonInstance = errors.New("err_get_addoninstance")
+	// Failed to update addoninstance status
+	ErrUpdateAddonInstanceStatus = errors.New("err_update_addon_instance_status")
+	// Failed to execute addoninstance reconcile phase
+	ErrExecuteAddonInstanceReconcilePhase = errors.New("err_execute_addon_instance_reconcile_phase")
+	// Failed to get default addonoperator
+	ErrGetDefaultAddonOperator = errors.New("err_get_default_addon_operator")
+	// Failed to create addonoperator
+	ErrCreateAddonOperator = errors.New("err_create_addon_operator")
+	// Failed to handle global pause of addon-operator
+	ErrAddonOperatorHandleGlobalPause = errors.New("err_addon_operator_handle_global_pause")
+	// Failed to create OCM client
+	ErrCreateOCMClient = errors.New("err_create_ocm_client")
+	// Failed to report addon-operator readiness status
+	ErrReportAddonOperatorStatus = errors.New("err_report_addonoperator_status")
 )

--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -113,6 +113,7 @@ func NewRecorder(register bool, clusterId string) *Recorder {
 		}, []string{
 			"controller",
 			"reason",
+			"cr_name",
 		},
 	)
 
@@ -328,8 +329,9 @@ func NewReconcileError(
 	return err
 }
 
-// Reports a reconcile error as a prometheus metric
-func (r *ReconcileError) Report(err error) {
+// Reports a reconcile error as a prometheus metric. The parameter crName
+// is the name of the CR being reconciled by the controller.
+func (r *ReconcileError) Report(err error, crName string) {
 	if r.recorder == nil {
 		return
 	}
@@ -344,6 +346,7 @@ func (r *ReconcileError) Report(err error) {
 	r.recorder.reconcileError.WithLabelValues(
 		r.controller,
 		r.reason,
+		crName,
 	).Inc()
 }
 


### PR DESCRIPTION
### What type of PR is this?
_feature_


### What this PR does / why we need it?
This PR implements collection of reconcile errors as metrics (prometheus). The purpose of these metrics is to enable SRE to;

1. Early alerting for ADO reconcile errors that when repeated anomalously will cause a user/customer impacting issue.

2. Analyse the trends of these errors and correlate them to real ones to understand which scenarios are potentially anomalous or not.

Implementation Overview
1. Created `ReconcileError` as a proxy object for reporting reconcile errors from reconcilers. 
2. Collected reconcile errors as prometheus GaugeVector metric called `addon_operator_reconcile_error` with labels `controller` and `reason` .
3. Modified reconcilers/subreconcilers to accept a Recorder instance so it can be used for reconcile error collection.
4. Recording of metrics are done at the top-level reconciler only to simplify and to ensure it's at the end of a reconcile. Subreconcilers on the other hand simply returns a basic `error`.

Tests
1. Unit tests are created for the ReconcileError use cases.
2. It was taking a lot of time for me already figuring out integration tests and running them reliabily in my local setup so I am deferring these tests for another task. IMO, integration-wise, there is little risk in these changes as they are mainly internal in ADO.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[MTSRE-1521](https://issues.redhat.com//browse/MTSRE-1521) #MTSRE-1572_


### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Ran `make test-unit` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR
- [ ] Squashed your commits
