### PR TITLE
MTSRE-1569 : cleanup additional catlog source 

### DIFF
--- a/integration/addon_test.go
+++ b/integration/addon_test.go
@@ -611,7 +611,7 @@ func (s *integrationTestSuite) TestAddonWithAdditionalCatalogSrc() {
 		}
 	})
 
-	addon = addonWithAdditionalCatalogSourceCleanup()
+	addon.Spec.Install.OLMOwnNamespace.AdditionalCatalogSources = nil
 	errs := integration.Client.Update(ctx, addon)
 	s.Require().NoError(errs)
 	err = integration.WaitForObject(

--- a/integration/addon_test.go
+++ b/integration/addon_test.go
@@ -593,7 +593,6 @@ func (s *integrationTestSuite) TestAddonWithAdditionalCatalogSrc() {
 	err = integration.Client.Get(ctx, client.ObjectKeyFromObject(addon), addon)
 	s.Require().NoError(err)
 	s.Assert().Equal(addon.Spec.Version, addon.Status.ObservedVersion, "addon version should be reported")
-
 	s.Run("test_additional_catalogsource", func() {
 		catalogSourceList := &operatorsv1alpha1.CatalogSourceList{}
 		err := integration.Client.List(ctx, catalogSourceList,
@@ -627,6 +626,8 @@ func (s *integrationTestSuite) TestAddonWithAdditionalCatalogSrc() {
 	err = integration.Client.Get(ctx, client.ObjectKeyFromObject(addon), addon)
 	s.Require().NoError(err)
 	s.Assert().Equal(addon.Spec.Version, addon.Status.ObservedVersion, "addon version should be reported")
+	//This will give the Reconciler the time to cleanup the unused catlog source
+	time.Sleep(8 * time.Minute)
 	s.Run("test_additional_catalogsource_cleanup_process", func() {
 		catalogSourceList := &operatorsv1alpha1.CatalogSourceList{}
 		err := integration.Client.List(ctx, catalogSourceList,

--- a/integration/addon_test.go
+++ b/integration/addon_test.go
@@ -611,7 +611,7 @@ func (s *integrationTestSuite) TestAddonWithAdditionalCatalogSrc() {
 		}
 	})
 
-	addon = addonWithVersion("v0.1.0", referenceAddonCatalogSourceImageWorkingLatest)
+	addon = addonWithAdditionalCatalogSourceCleanup()
 	errs := integration.Client.Update(ctx, addon)
 	s.Require().NoError(errs)
 	err = integration.WaitForObject(

--- a/integration/addon_test.go
+++ b/integration/addon_test.go
@@ -611,7 +611,7 @@ func (s *integrationTestSuite) TestAddonWithAdditionalCatalogSrc() {
 		}
 	})
 
-	addon.Spec.Install.OLMOwnNamespace.AdditionalCatalogSources = nil
+	addon.Spec.Install.OLMOwnNamespace.AddonInstallOLMCommon.AdditionalCatalogSources = nil
 	errs := integration.Client.Update(ctx, addon)
 	s.Require().NoError(errs)
 	err = integration.WaitForObject(

--- a/integration/addon_test.go
+++ b/integration/addon_test.go
@@ -611,9 +611,15 @@ func (s *integrationTestSuite) TestAddonWithAdditionalCatalogSrc() {
 	})
 
 	// With lesser number of Additional Catlog source
+	s.T().Log("Lesser Additional Catlog Source")
 	err = integration.Client.Get(ctx, client.ObjectKeyFromObject(addon), addon)
 	s.Require().NoError(err)
-	addon = addonWithLessAdditionalCatalogSource()
+	addon.Spec.Install.OLMOwnNamespace.AddonInstallOLMCommon.AdditionalCatalogSources = []addonsv1alpha1.AdditionalCatalogSource{
+		{
+			Name:  "test-1",
+			Image: referenceAddonCatalogSourceImageWorking,
+		},
+	}
 	err = integration.Client.Update(ctx, addon)
 	s.Require().NoError(err)
 	err = integration.WaitForObject(
@@ -636,8 +642,9 @@ func (s *integrationTestSuite) TestAddonWithAdditionalCatalogSrc() {
 			client.InNamespace(addon.Spec.Install.OLMOwnNamespace.Namespace),
 		)
 		s.Assert().NoError(err, "could not get CatalogSource %s", addon.Name)
-		s.Assert().Equal(1, len(catalogSourceList.Items))
+		s.Assert().Equal(2, len(catalogSourceList.Items))
 		expectedImages := map[string]string{
+			"test-1":                           referenceAddonCatalogSourceImageWorking,
 			addonUtil.CatalogSourceName(addon): referenceAddonCatalogSourceImageWorking,
 		}
 		for _, ctlgSrc := range catalogSourceList.Items {
@@ -646,6 +653,7 @@ func (s *integrationTestSuite) TestAddonWithAdditionalCatalogSrc() {
 	})
 
 	// With Zero Additional Catlog Source
+	s.T().Log("Zero Additional Catlog Source")
 	err = integration.Client.Get(ctx, client.ObjectKeyFromObject(addon), addon)
 	s.Require().NoError(err)
 	addon.Spec.Install.OLMOwnNamespace.AddonInstallOLMCommon.AdditionalCatalogSources = nil

--- a/integration/addon_test.go
+++ b/integration/addon_test.go
@@ -610,10 +610,11 @@ func (s *integrationTestSuite) TestAddonWithAdditionalCatalogSrc() {
 			s.Assert().Equal(expectedImages[ctlgSrc.Name], ctlgSrc.Spec.Image)
 		}
 	})
-
+	err = integration.Client.Get(ctx, client.ObjectKeyFromObject(addon), addon)
+	s.Require().NoError(err)
 	addon.Spec.Install.OLMOwnNamespace.AddonInstallOLMCommon.AdditionalCatalogSources = nil
-	errs := integration.Client.Update(ctx, addon)
-	s.Require().NoError(errs)
+	err = integration.Client.Update(ctx, addon)
+	s.Require().NoError(err)
 	err = integration.WaitForObject(
 		ctx,
 		s.T(), defaultAddonAvailabilityTimeout, addon, "to be Available",

--- a/integration/fixtures_test.go
+++ b/integration/fixtures_test.go
@@ -215,6 +215,42 @@ func addonWithAdditionalCatalogSource() *addonsv1alpha1.Addon {
 	}
 }
 
+func addonWithLessAdditionalCatalogSource() *addonsv1alpha1.Addon {
+	return &addonsv1alpha1.Addon{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "addon-oisafbo123",
+		},
+		Spec: addonsv1alpha1.AddonSpec{
+			Version:     "v0.3.0",
+			DisplayName: "addon-oisafbo12",
+			Namespaces: []addonsv1alpha1.AddonNamespace{
+				{Name: "namespace-onbgdions1"},
+				{Name: "namespace-pioghfndb1"},
+			},
+			Install: addonsv1alpha1.AddonInstallSpec{
+				Type: addonsv1alpha1.OLMOwnNamespace,
+				OLMOwnNamespace: &addonsv1alpha1.AddonInstallOLMOwnNamespace{
+					AddonInstallOLMCommon: addonsv1alpha1.AddonInstallOLMCommon{
+						Namespace:          "namespace-onbgdions1",
+						CatalogSourceImage: referenceAddonCatalogSourceImageWorking,
+						Channel:            "alpha",
+						PackageName:        "reference-addon",
+						Config: &addonsv1alpha1.SubscriptionConfig{
+							EnvironmentVariables: referenceAddonConfigEnvObjects,
+						},
+						AdditionalCatalogSources: []addonsv1alpha1.AdditionalCatalogSource{
+							{
+								Name:  "test-1",
+								Image: referenceAddonCatalogSourceImageWorking,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func addon_AllNamespaces() *addonsv1alpha1.Addon {
 	return &addonsv1alpha1.Addon{
 		ObjectMeta: metav1.ObjectMeta{

--- a/integration/fixtures_test.go
+++ b/integration/fixtures_test.go
@@ -215,36 +215,6 @@ func addonWithAdditionalCatalogSource() *addonsv1alpha1.Addon {
 	}
 }
 
-func addonWithAdditionalCatalogSourceCleanup() *addonsv1alpha1.Addon {
-	return &addonsv1alpha1.Addon{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "addon-oisafbo123",
-		},
-		Spec: addonsv1alpha1.AddonSpec{
-			Version:     "v0.3.0",
-			DisplayName: "addon-oisafbo12",
-			Namespaces: []addonsv1alpha1.AddonNamespace{
-				{Name: "namespace-onbgdions1"},
-				{Name: "namespace-pioghfndb1"},
-			},
-			Install: addonsv1alpha1.AddonInstallSpec{
-				Type: addonsv1alpha1.OLMOwnNamespace,
-				OLMOwnNamespace: &addonsv1alpha1.AddonInstallOLMOwnNamespace{
-					AddonInstallOLMCommon: addonsv1alpha1.AddonInstallOLMCommon{
-						Namespace:          "namespace-onbgdions1",
-						CatalogSourceImage: referenceAddonCatalogSourceImageWorking,
-						Channel:            "alpha",
-						PackageName:        "reference-addon",
-						Config: &addonsv1alpha1.SubscriptionConfig{
-							EnvironmentVariables: referenceAddonConfigEnvObjects,
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
 func addon_AllNamespaces() *addonsv1alpha1.Addon {
 	return &addonsv1alpha1.Addon{
 		ObjectMeta: metav1.ObjectMeta{

--- a/integration/fixtures_test.go
+++ b/integration/fixtures_test.go
@@ -215,42 +215,6 @@ func addonWithAdditionalCatalogSource() *addonsv1alpha1.Addon {
 	}
 }
 
-func addonWithLessAdditionalCatalogSource() *addonsv1alpha1.Addon {
-	return &addonsv1alpha1.Addon{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "addon-oisafbo123",
-		},
-		Spec: addonsv1alpha1.AddonSpec{
-			Version:     "v0.3.0",
-			DisplayName: "addon-oisafbo12",
-			Namespaces: []addonsv1alpha1.AddonNamespace{
-				{Name: "namespace-onbgdions1"},
-				{Name: "namespace-pioghfndb1"},
-			},
-			Install: addonsv1alpha1.AddonInstallSpec{
-				Type: addonsv1alpha1.OLMOwnNamespace,
-				OLMOwnNamespace: &addonsv1alpha1.AddonInstallOLMOwnNamespace{
-					AddonInstallOLMCommon: addonsv1alpha1.AddonInstallOLMCommon{
-						Namespace:          "namespace-onbgdions1",
-						CatalogSourceImage: referenceAddonCatalogSourceImageWorking,
-						Channel:            "alpha",
-						PackageName:        "reference-addon",
-						Config: &addonsv1alpha1.SubscriptionConfig{
-							EnvironmentVariables: referenceAddonConfigEnvObjects,
-						},
-						AdditionalCatalogSources: []addonsv1alpha1.AdditionalCatalogSource{
-							{
-								Name:  "test-1",
-								Image: referenceAddonCatalogSourceImageWorking,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
 func addon_AllNamespaces() *addonsv1alpha1.Addon {
 	return &addonsv1alpha1.Addon{
 		ObjectMeta: metav1.ObjectMeta{

--- a/integration/fixtures_test.go
+++ b/integration/fixtures_test.go
@@ -215,6 +215,36 @@ func addonWithAdditionalCatalogSource() *addonsv1alpha1.Addon {
 	}
 }
 
+func addonWithAdditionalCatalogSourceCleanup() *addonsv1alpha1.Addon {
+	return &addonsv1alpha1.Addon{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "addon-oisafbo123",
+		},
+		Spec: addonsv1alpha1.AddonSpec{
+			Version:     "v0.3.0",
+			DisplayName: "addon-oisafbo12",
+			Namespaces: []addonsv1alpha1.AddonNamespace{
+				{Name: "namespace-onbgdions1"},
+				{Name: "namespace-pioghfndb1"},
+			},
+			Install: addonsv1alpha1.AddonInstallSpec{
+				Type: addonsv1alpha1.OLMOwnNamespace,
+				OLMOwnNamespace: &addonsv1alpha1.AddonInstallOLMOwnNamespace{
+					AddonInstallOLMCommon: addonsv1alpha1.AddonInstallOLMCommon{
+						Namespace:          "namespace-onbgdions1",
+						CatalogSourceImage: referenceAddonCatalogSourceImageWorking,
+						Channel:            "alpha",
+						PackageName:        "reference-addon",
+						Config: &addonsv1alpha1.SubscriptionConfig{
+							EnvironmentVariables: referenceAddonConfigEnvObjects,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func addon_AllNamespaces() *addonsv1alpha1.Addon {
 	return &addonsv1alpha1.Addon{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controllers/addon/phase_ensure_catalogsource.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource.go
@@ -202,9 +202,11 @@ func cleanupOldAdditionalCatalogSources(ctx context.Context, c client.Client, ad
 	for i := range catalogSourceList.Items {
 		catalogsrc := &catalogSourceList.Items[i]
 		if catalogsrc.Name != knownCatsrc {
+			fmt.Println("deleting the unused additional catlog source : ", catalogsrc.Name)
 			if err := c.Delete(ctx, catalogsrc); err != nil {
 				return fmt.Errorf("deleting additional catsrc failed : %w", err)
 			}
+
 		}
 
 	}

--- a/internal/controllers/addon/phase_ensure_catalogsource.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource.go
@@ -200,7 +200,7 @@ func cleanupOldAdditionalCatalogSources(ctx context.Context, c client.Client, ad
 		catalogsrc := &catalogSourceList.Items[i]
 		if catalogsrc.Name != knownCatsrc {
 			if err := c.Delete(ctx, catalogsrc); err != nil {
-				return fmt.Errorf("deleting unknown propagated secret: %w", err)
+				return fmt.Errorf("deleting additional catsrc failed : %w", err)
 			}
 		}
 

--- a/internal/controllers/addon/phase_ensure_catalogsource.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource.go
@@ -220,16 +220,22 @@ func cleanupOldAdditionalCatalogSources(ctx context.Context, c client.Client, ad
 	}
 	for i := range catalogSourceList.Items {
 		catalogsrc := &catalogSourceList.Items[i]
-		for _, cs := range knownCatsrc {
-			if catalogsrc.Name != cs {
-				fmt.Println("deleting the unused additional catlog source : ", catalogsrc.Name)
-				if err := c.Delete(ctx, catalogsrc); err != nil {
-					return fmt.Errorf("deleting additional catsrc failed : %w", err)
-				}
+		// once we move to 1.21 we can use slices.Contains
+		if !Contains(knownCatsrc, catalogsrc.Name) {
+			fmt.Println("deleting the unused additional catlog source : ", catalogsrc.Name)
+			if err := c.Delete(ctx, catalogsrc); err != nil {
+				return fmt.Errorf("deleting additional catsrc failed : %w", err)
 			}
 		}
-
 	}
 	return nil
+}
 
+func Contains(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/controllers/addon/phase_ensure_catalogsource.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource.go
@@ -89,13 +89,13 @@ func (r *olmReconciler) ensureAdditionalCatalogSources(
 ) (requeueResult, error) {
 	if !HasAdditionalCatalogSources(addon) {
 		// cleanup old AdditionalCatalogSources when moving from existing AdditionalCatalogSources to no AdditionalCatalogSources
-		if err := cleanupOldAdditionalCatalogSources(ctx, r.client, addon); err != nil {
+		if err := cleanupUnusedAdditionalCatalogSources(ctx, r.client, addon); err != nil {
 			return resultNil, fmt.Errorf("unused additional catsrc cleanup: %w", err)
 		}
 		return resultNil, nil
 	}
 	// cleanup old AdditionalCatalogSources when moving from existing AdditionalCatalogSources to less number of AdditionalCatalogSources
-	if err := cleanupOldAdditionalCatalogSources(ctx, r.client, addon); err != nil {
+	if err := cleanupUnusedAdditionalCatalogSources(ctx, r.client, addon); err != nil {
 		return resultNil, fmt.Errorf("unused additional catsrc cleanup: %w", err)
 	}
 
@@ -191,7 +191,7 @@ func reconcileCatalogSource(ctx context.Context, c client.Client, catalogSource 
 	return currentCatalogSource, nil
 }
 
-func cleanupOldAdditionalCatalogSources(ctx context.Context, c client.Client, addon *addonsv1alpha1.Addon) error {
+func cleanupUnusedAdditionalCatalogSources(ctx context.Context, c client.Client, addon *addonsv1alpha1.Addon) error {
 	//Get the catlog source from Addon and make it part of a List
 	knownCatsrc := []string{CatalogSourceName(addon)}
 	catalogSourceList := &operatorsv1alpha1.CatalogSourceList{}
@@ -231,9 +231,9 @@ func cleanupOldAdditionalCatalogSources(ctx context.Context, c client.Client, ad
 	return nil
 }
 
-func Contains(a []string, x string) bool {
-	for _, n := range a {
-		if x == n {
+func Contains(list []string, element string) bool {
+	for _, val := range list {
+		if element == val {
 			return true
 		}
 	}

--- a/internal/controllers/addon/phase_ensure_catalogsource.go
+++ b/internal/controllers/addon/phase_ensure_catalogsource.go
@@ -90,7 +90,7 @@ func (r *olmReconciler) ensureAdditionalCatalogSources(
 	if !HasAdditionalCatalogSources(addon) {
 		// cleanup old AdditionalCatalogSources when moving from existing AdditionalCatalogSources to no AdditionalCatalogSources
 		if err := cleanupOldAdditionalCatalogSources(ctx, r.client, addon); err != nil {
-			return resultNil, fmt.Errorf("propagated secret cleanup: %w", err)
+			return resultNil, fmt.Errorf("unused additional catsrc cleanup: %w", err)
 		}
 		return resultNil, nil
 	}
@@ -191,10 +191,13 @@ func cleanupOldAdditionalCatalogSources(ctx context.Context, c client.Client, ad
 	knownCatsrc := CatalogSourceName(addon)
 	catalogSourceList := &operatorsv1alpha1.CatalogSourceList{}
 	// Get a List of all Catlog Source Managed by the addon
-	if err := c.List(ctx, catalogSourceList, client.MatchingLabelsSelector{
-		Selector: controllers.CommonLabelsAsLabelSelector(addon),
+	selector := controllers.CommonLabelsAsLabelSelector(addon)
+	if err := c.List(ctx, catalogSourceList, &client.ListOptions{
+		LabelSelector: client.MatchingLabelsSelector{
+			Selector: selector,
+		},
 	}); err != nil {
-		return fmt.Errorf("listing catsrc for delete check: %w", err)
+		return fmt.Errorf("listing additional catsrc for delete failed: %w", err)
 	}
 	for i := range catalogSourceList.Items {
 		catalogsrc := &catalogSourceList.Items[i]

--- a/internal/testutil/matchers.go
+++ b/internal/testutil/matchers.go
@@ -25,11 +25,12 @@ var (
 	IsNetworkingV1NetworkPolicyPtr = mock.IsType(&networkingv1.NetworkPolicy{})
 
 	// olm
-	IsOperatorsV1OperatorGroupPtr       = mock.IsType(&operatorsv1.OperatorGroup{})
-	IsOperatorsV1Alpha1CatalogSourcePtr = mock.IsType(&operatorsv1alpha1.CatalogSource{})
-	IsOperatorsV1Alpha1SubscriptionPtr  = mock.IsType(&operatorsv1alpha1.Subscription{})
-	IsOperatorsV1OperatorPtr            = mock.IsType(&operatorsv1.Operator{})
-	IsOperatorsV1Alpha1InstallPtr       = mock.IsType(&operatorsv1alpha1.InstallPlan{})
+	IsOperatorsV1OperatorGroupPtr           = mock.IsType(&operatorsv1.OperatorGroup{})
+	IsOperatorsV1Alpha1CatalogSourcePtr     = mock.IsType(&operatorsv1alpha1.CatalogSource{})
+	IsOperatorsV1Alpha1SubscriptionPtr      = mock.IsType(&operatorsv1alpha1.Subscription{})
+	IsOperatorsV1OperatorPtr                = mock.IsType(&operatorsv1.Operator{})
+	IsOperatorsV1Alpha1InstallPtr           = mock.IsType(&operatorsv1alpha1.InstallPlan{})
+	IsOperatorsV1Alpha1CatalogSourceListPtr = mock.IsType(&operatorsv1alpha1.CatalogSourceList{})
 
 	// prom
 	IsMonitoringV1ServiceMonitorPtr = mock.IsType(&monitoringv1.ServiceMonitor{})


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_

https://issues.redhat.com/browse/MTSRE-1569 :
More Context here : https://redhat-internal.slack.com/archives/C045X0P531D/p1697535315447999

It seems to occur in cluster where earlier the addon had additionalCatalogSources configured and in current version its not present .This results in the additionalCatalogSources being present on the cluster even after the new version release .

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/MTSRE-1569
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make test-unit` command locally to run all the unit tests and mock tests locally.
- [x] Included documentation changes with PR
- [x] Squashed your commits
