### PR TITLE
Ensure Addon Operator Makefile targets has no conflicts with the golang-osd-operator convention's Makefile targets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,7 @@ repos:
     always_run: true
 
 # Temporarily disabling make-generate
+# TODO: Add this back in after boilerplate migration complete
   # - id: make-generate
   #   name: make-generate
   #   entry: make generate

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,9 @@ version:
 .PHONY: version
 
 ## Cleans cached binaries, dependencies and container image tars.
-clean: delete-kind-cluster
+clean-binaries: delete-kind-cluster
 	@rm -rf bin .cache
-.PHONY: clean
+.PHONY: clean-binaries
 
 # ---------
 ##@ Compile
@@ -129,18 +129,18 @@ tidy:
 # ------------
 
 ## Generate deepcopy code, kubernetes manifests and docs.
-generate:
+generate-all:
 	./mage generate:all
-.PHONY: generate
+.PHONY: generate-all
 
 # ---------------------
 ##@ Testing and Linting
 # ---------------------
 
 ## Runs code-generators, checks for clean directory and lints the source code.
-lint:
+lint-mage:
 	./mage test:lint
-.PHONY: lint
+.PHONY: lint-mage
 
 ## Runs unittests.
 test-unit:

--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,13 @@ push-image-%:
 clean-config-openshift:
 	@rm -rf "config/openshift/*"
 
+# ------------------
+##@ Codecov.io
+# ------------------
+.PHONY: coverage
+coverage:
+	hack/codecov.sh
+
 ensure-govulncheck:
 	@ls $(GOPATH)/bin/govulncheck 1>/dev/null || go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
 

--- a/Makefile
+++ b/Makefile
@@ -129,9 +129,9 @@ tidy:
 # ---------------------
 
 ## Runs code-generators, checks for clean directory and lints the source code.
-lint-mage:
+lint:
 	./mage test:lint
-.PHONY: lint-mage
+.PHONY: lint
 
 ## Runs unittests.
 test-unit:

--- a/Makefile
+++ b/Makefile
@@ -295,13 +295,6 @@ push-image-%:
 clean-config-openshift:
 	@rm -rf "config/openshift/*"
 
-# ------------------
-##@ Codecov.io
-# ------------------
-.PHONY: coverage
-coverage:
-	hack/codecov.sh
-
 ensure-govulncheck:
 	@ls $(GOPATH)/bin/govulncheck 1>/dev/null || go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
 

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,9 @@ version:
 .PHONY: version
 
 ## Cleans cached binaries, dependencies and container image tars.
-clean-binaries: delete-kind-cluster
+clean-setup: delete-kind-cluster
 	@rm -rf bin .cache
-.PHONY: clean-binaries
+.PHONY: clean-setup
 
 # ---------
 ##@ Compile
@@ -123,15 +123,6 @@ helm:
 ## Run go mod tidy in all go modules
 tidy:
 	@go mod tidy
-
-# ------------
-##@ Generators
-# ------------
-
-## Generate deepcopy code, kubernetes manifests and docs.
-generate-all:
-	./mage generate:all
-.PHONY: generate-all
 
 # ---------------------
 ##@ Testing and Linting

--- a/config/olm/addon-operator.csv.yaml
+++ b/config/olm/addon-operator.csv.yaml
@@ -1,0 +1,409 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Full Lifecycle
+    containerImage: quay.io/openshift/addon-operator:latest
+    olm.skipRange: '>=0.0.1 <1.13.9'
+    repository: https://github.com/openshift/addon-operator
+    support: "false"
+  creationTimestamp: null
+  name: addon-operator.v1.13.9
+spec:
+  apiservicedefinitions: {}
+  cleanup:
+    enabled: false
+  customresourcedefinitions:
+    owned:
+    - description: Represents the deployment of an Addon for Managed OpenShift
+      displayName: Managed Openshift Addon
+      kind: Addon
+      name: addons.addons.managed.openshift.io
+      statusDescriptors:
+      - description: The deployment phase.
+        displayName: Phase
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Detailed status conditions.
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+    - description: Represents the overall status of the Addon Operator
+      displayName: Addon Operator
+      kind: AddonOperator
+      name: addonoperators.addons.managed.openshift.io
+      version: v1alpha1
+  description: Addon Operator coordinates the lifecycle of Addons in managed OpenShift.
+  displayName: Managed OpenShift Addon Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAASwAAAEsCAYAAAB5fY51AAAACXBIWXMAABdIAAAXSAGK3kwdAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAGMpJREFUeJzt3XmYHVWdxvHvqU7TQLa+vSRkYUcB2RKILJEIGtBxQQWfEQQRYdRBEQigjOs8z4wbo4IEXNBxZFXBeQBFnRkFlDUIE5YgKBmWAFkgdPe9nYSQdJK+Z/6oTp4ASfrW7Vv1q1P3/fyTpJ901ds3nbdP1T11jkOkAJbDxFY42MFeVdjLwV7AZGCchzEOdgDGAqs8rHHwMrASWObhKQdPAk+3woNj4SXDL0W2wVkHEKnHSugchPcAb/VwJLB3Aw//hIN7gLsi+N14KDfw2DICKiwJRg+MHQUf8HAScCzQmsFp1wG3AtcPwq+7YVUG55StUGFJ7r0EO7XAmQ7OAUqGUVZ5uNLBxR3wvGGOpqXCktyqwK4evko8ospiNFWr9R5+7uCfVVzZUmFJ7iyDHdvgQgcXEt8sz6s1wGWD8HVdKmZDhSW50gvHRHAlMNU6SwKLIzi9HW63DlJ0kXUAEQAPbWW4KILfE1ZZAexchVv7YK6HNuswRaYRlpjrhSkR/AaYbp2lAR4chPd1wzLrIEWkwhJTZTgA+C2wi3WWBloWwXHt8JB1kKLRJaGY6Ye3A/MoVlkBTK7CHRV4m3WQotEIS0z0wUwX368aY50lRa84eFcJ7rIOUhQqLMlcLxwawW3Ez/YV3coIZrfDfOsgRaDCkkz1wKSW+D/vZOssGXqxCjO6YKl1kNDpHpZkxkNbC9xMc5UVwE4R/KemPIycCksyU4ZvAYdZ5zByRD980zpE6HRJKJkYusl+N839Q7IKHNURL10jdVBhSeoWww6j4VHiRfWa3RMlmOZgwDpIiJr5p51kZDScjcpqo33K8GnrEKHSCEtSVYbxwNNAp3WWHOn1sGdnvESzJKARlqTKwRxUVq/VFcG51iFCpBGWpMbDqAo8C0yxzpJDL5RgVwfrrYOERCMsSU0ZTkBltTWT+uE46xChUWFJahx8xDpDnnk41TpDaHRJKKkYmsrQC+xonSXHVq+Art1hrXWQUGiEJakYDUejshrO6HFwlHWIkKiwJBW+eR/BSSTS65SICktS4eAg6wyBONA6QEhUWJKWfawDhMDDvtYZQqLCklR46LDOEAi9TgmosCQVLn4kR4ZXsg4QEhWWpKXFOkAg9H8wAb1YkhbNLarNGusAIVFhSVpWWAcIhF6nBFRYkgqnDRdqtcQ6QEhUWJIKD89YZwjEIusAIVFhSVoetQ4QiEesA4REhSWpcHCfdYZA6HVKQKs1SCo8bFeJV2toht2d67WyBF1axK92GmFJKhysc3CDdY6c+4XKKhkVlqTp+9YB8iyCH1tnCI0KS1JTgkccPGCdI6fmtcND1iFCo8KSVHm4IP5FNuMdfNE6RIhUWJKqoW3Zf2adI088XF2CO61zhEjvEkrqlsPEVngYmGSdJQeWtcL0sfCSdZAQaYQlqZsIyz18EBiwzmJsPXCiyqp+KizJRCfc5+Ez1jkMeQf/OHSJLHVSYUlmOuEnDs6zzmHk8yW40jpE6FRYkqkSXAp82TpHxr7YAd+yDlEEuukuJspwFnA5xf4e9B4+2wmXWAcpiiJ/s0jOleGTwA8p5kjfOzi3FJeyNIgKS0yV4WTgamCUdZYGGnTw8RJcZR2kaFRYYq4MJxFPLi3CSKsKnNIB11sHKaIifINI4Ib+cxdiyoOD81VW6VFhSS50xPeygr7f4+HSEsy1zlFkuiSU3PDQVoH7gYOss9ThsRXw5t21vVmqVFiSKxWY7mE+YY3+qw4OLsEC6yBFF9I3hTSBUvyQ9M+tcyTh4RqVVTY0wpLc6YG9W+BvhPH96VvgjePhKesgzUAjLMmdblgIzLPOUaO7VVbZUWFJLnm4yTpDLRzcbJ2hmaiwJJdc/G5h7g1qX8FMqbAkl1rhSesMtQglZ1GosCSX+mGVdYZajIOXrTM0ExWW5FI7jLHOUIuVgeQsChWW5NIA7G6doRYe9rDO0ExUWJJLEcy2zlCLaiA5i0KFJbnj4wmjH7LOUaOTfBgTXAtBhSW5U47Lapp1jhpNK8dbmEkG9JNBcqUHJrXEDz9Pts6SwNINMGMCvGgdpOg0wpLcKMP4lniGe0hlBTBlFNzUB+OsgxSdCktyoQK7EW8yerhxlHod4eDuCuxqHaTIVFhiykNrH5zv4S/A/tZ5RuhAD4/1wXkeWq3DFJHuYYmJMuzi4KMePkV4l4C1WAr80MM1nbDYOkxRqLAkNR7aVsJoD+0edvawt4f9HBwDvMk6X4Ye93Ab8HgECx0sASrj4RUHA9bhQqLCSqAM3jqDSDPTPSwRCYYKS0SCocISkWCosEQkGCosEQmGCktEgqHCEpFgqLBEJBgqLBEJhgpLRIKhwhKRYKiwRCQYKiwRCYYKS0SCocISkWCosEQkGCosEQmGCktEgqHCEpFgqLBEJBgqLBEJhgpLRIKhwhKRYKiwRCQYKiwRCYYKS0SCocISkWCosEQkGCosEQmGCktEgqHCEpFgqLBEJBgqLBEJhgpLRIKhwhKRYKiwRCQYKiwRCYYKS0SCocISkWCosEQkGCosEQmGCktEgqHCEpFgqLBEJBgqLBEJhgpLRIKhwhKRYKiwRCQYKiwRCYYKS0SCocISkWCosEQkGCosEQmGCktEgqHCEpFgqLBEJBgqLBEJhgpLRIKhwhKRYKiwRCQYKiwRCYYKS0SCocISkWCosEQkGCosEQmGCktEgqHCEpFgqLBEJBgqLBEJhgpLRIKhwhKRYKiwRCQYKiwRCYYKS0SCMSrtEyyGHUbD0Q4OrcKBDt7koOShHWgDKsCa+K/yLPCIgz+3wzwH69LOJ9IE1gJ/8vBABI8Owl8HoTIB+h0M9ENpPezgYGcHuzmYBhwOzAS2s43+ai6Ng3poLcMHHHwEOAbYsY7DrHJwg4Mr2uHBBkdMzENbJf6HFwnBege/Aq5bA7dNhleSHqAHxkZwooMzgUMaHzGxgYYWVhnGOzjXx1/gpEYd18EDwIUluLNRx0xqJXRtgB6r84vUaIWHuVW4ohteaNRBe+HQCL4FHNWoY9YToyGFNXTZ9xng80BHI465BR64bj18biIsT+kcW1WB3Twsyvq8IjVaA3yvBS4aD+U0TuDB9cdXTd/2MDGNcwzj2REXVh/MdPBTYO8GBKpFj4MPleCOjM4HQAWO8hmfU6RG8wbhjG5YmMXJVkH3evglcHQW59vMnXW/S+ihrQ/mOrib7MoKoNvD7/vg4xmeE5/t1yhSiwEH55ZgVlZlBTAWekrwTgc/yeqcQxbW9S5hL0ypwI0ODmt0ohpt5+Df+6C9E76TxQk97JfKOxQi9VlahQ92wf0WJx96B/8TZegHPpvROR9PPMIauvk2H7uy2sTBt8vwpYzOdUwW5xEZjoMHNsAMq7LaXAd8Dvh6Fueqwm2JBg1lmAX8DhibTqT6ePhsJ1yc1vHLsAvwXFrHF0ng7kF4Tzessg6yuQp8x8MFKZ7i+Q7YteYRVj+8HfhvclZWsGmkdWaKxz8trWOL1MrDH9fBu/JWVgDt8UjrirSO7+FqqHHiaAWm+fjm+pi0AjVA1cHpJbimkQf10FqJZ+BPbuRxRRJ6ZAPMmgAvWwfZGg9RBa4EPtrgQ68fhN26YdmwI6xemOLht+S7rAAiDz8tw0mNPGgZzkFlJbaWVuG9eS4rAAfVEpwBXN/g417eDcuGfr91Q4+jzAMObmSAlFUdzCnB5SM9UD/sXoW/AKMbkEukHgMRzGyHh6yD1GpopHUpcHYDDvfsBjhgY1lvc4TVD98krLKCeKR1WRkuWwTb13uQMoyvwi2orMSQhy+EVFYQj7Q64BwXX52M5PnbFcBxm48stzrC6oNjHfx+W38nAI86+FgJHk7yST0wuQVuIgdTN6R5Obi1PZ6g6a2z1KsMBwJXAdMTfuoLHk7ohD9v/sEtjrBehNFDj9uEXFYAB3qYX4Zre+CNw/1lD64PTmzJyTwzaWqrq3BGyGUF0AGPlmAGcKqD/6vhUzzwy0GY8dqygq0UUh981cGXR5g1j+718Qz9B0bBwhWwuh3GDMDuEcwGTgQOsg4p4uArJfiadY5GK8ORDk7wcCjx426jgdUOFnm43cH1JViwtc9/XWH1xYt4PUF9a1iJyMgtXgv71LOGVdG97pLQxdPsVVYiRhx8SWW1Za8aYfXBVAfPAK1GeUSa3ZIS7OFgvXWQPIpe84c5qKxEzHi4VGW1dZtGWD0wtgWWAOMM84g0s1UepnbCSusgebVphDUKjkdlJWLpZpXVtm0qLN/gZ/BEJLGGPoNXRA5gBXQMxjts5GoPMpEmUi7BJO3FuW0RQBXei8pKxNJvVVbD23hJ+FbTFCJNzsNd1hlCsLGwZpmmEGly1XiBTBmGWw4TW+FF6yAizcrB8hLsZJ0jBFFreOtdiRSKD2y9K0uRgzdYhxBpZh6etM4QiqgKe1qHEGlmETxtnSEUkYO9rEOINDMPT1lnCEUETLUOIdLkllgHCEVE/rfvEim0KOfbd+VJ5FVYIqZaVFg1i5y2sRIxtRpWW2cIRcQI9u4TkZGbOLK9+5pKhF4sEVPLNWioWeQ1HBUxNVq3ZWoWOd3wEzE1qDe+ahYBq6xDiDQzD2OtM4QiApZahxBpZh6mWGcIRaTHAkRs6fG42kV68FLElhYgqF2kpS1EbGmJp9pFrTAf8NZBRJrYDL/ZpsayddFY6HEaZYlY6u7VKKsmGzeh0I4dIoYi7VxVExWWSA44FVZNHEA/lKrxzjnaTFXERqUEO2kz1W2LANqhAvzBOItIMytV4B3WIfIu2uz3N5ilEBGAE60D5N2mt1J7YGwLLAbGG+YRaWargJ07YIV1kLzaNMLqjl+sHxtmEWl2Y4FPWofIs1dNVuuFKRE8g26+i1hZWoI9dPN9yza/h0UXLPXwC6swIsKUfviwdYi8et3jAH0w1cETaBVEEStL1sE+O2k14NeJXvuBTlji4WKLMCnzwF0O5lTh8Ag6SjDKQcnBwcCFwEPGGUUAprbBBdYhGs2DK8OsPvhuGe4rQ18Z1g39Or8MF1Vg2raOscUHLpfBjtvHo6ydU0meraqHa1rga+3DLKXjwfXD8R7moh2xxdYrHvbpjN+5D5qHqB9O9fBlhl/7yzu4cRDmdG1hcdGtPiHeD7Or8WTS143CAvKIg4+VYEGST1oOE1vhRuAtKeUSGZaH2zvgHQ6q1lnqVYFpHq4CDkr4qS96OKET7tv8g1sto3a43cF368iYCx4uLcHhScsKYCIs9/Bu6vhckUZxMLsM51nnqFcF5nj4M8nLCuLHlP6nDAds/sFtrsHjoa0C9wKH1HFCK1XgnA74/kgPVIZdgMfQJgFiZyCCt7TDg9ZBauUhqsBlwFkNONxzG2D/CUO7e23zcs/BwCC8D1jSgBNnYQNwSiPKCqADnnfwz404lkid2qpwS18g91Q9jKrAz2hMWQHs2gr/uvEPNa1yWIGDPNxNvkca1aH7Vdc28qAeWiuwCO1sIrYWDMKs7hxvyzc0sroKOLXBh15fhd27YGlNN9RLsMDB+8nvpqse+HSjywrAwXrgh40+rkhCB7XAr1/K6aarHlwFfkDjywqg1cGZkHAd6XL8rtl/AeNSCFU3Dxd0wiVpHb8PdnbwfFrHF0ngXg/v7oSV1kE2V4GLPZyf4ikWd8AuiRe+74cZVfg1MDmFUPX4Ygd8M+2TlOOb7/ulfR6R4XiYX4X3d8My6ywAZfgG8IW0z+Nh/8RzrNph/iDMAOalkCkJ7+H8LMoKwMNtWZxHZDgOZrTA/D6YaZlj6DLwEjIoK4AIZtc1KbQbXijB24bmaVlMahtw8A+d2c4TezzDc4kMZ5KDP/XBed5gcreHtjL8h89wnlhdI6yNHKwrwfkejgT+1sBcw1nm4egSXJnhOYlgYZbnE6nBdg4uqcA9vbBvViftgckVuMPB6Vmdc8jeI27mTrivBNOHbrj1NiDU1ngPV7fC9M549mzWdNNd8uqICB6uwCUroSutkwxdAp4WwcPA4WmdZxuS33Tflj4YF8E5Pn4LspHzluYB/9QB9zTwmImshK4N0GN1fpEarfRwmYcrtvTwcL36YKaDfyO+orLSm8r22B5G9cP7qvARF+8EUs/aWiuBXzi4ogSPNDhiYkOPKa21ziFSow0ebongugH4Qz1ra/XBOBcvJngmwyz7kpGBVAprc4tg+3FwVASHAgf6eGpACWgH2oB+4BXgOeBZ4geO55Xg/qFJm7lRjieoioRmLXCnhweARz08XoXKaujfDQZWQPsG2NHBrg52I35YeSZwGNBqF/v1Ui+sIlFh5ZeLV9h4CHjKwVM+/nWZg5Ut8PJaWNMNq3pg7PawwyCM8TDOw2QHe3l4A7Cnh0McTLD+emTLVFgJqLBypQ/4nYe7qnBPdwPfxe2FfRwcObR9/HuAjkYdW0ZGhZWACsvcKuBXwPUluDWLWwYetqvAscBJxM/T5nkBgMJTYSWgwjLzoocftcDcdqhYheiBsaPgjKEpPLtY5WhmKqwEVFiZe87BV9rh+jy9AeOhtR9O9vE6TSquDIW8XrsU1yse/mU17FuCa/NUVhAvOVSCq1fDPsDnyfEaVUWjEVYCGmGlz8FtVTi9M5xVbumLd5e60sFs6yxFpxGW5MUA8Pl2eGdIZQXQGa/VdKyDOcRfh6REI6wENMJKzVIHx5XiZ9SC1g+HVOEW8rNeXKFohCXW/gLMLEJZAbTDg4PwZrSLeCpUWGLGwx83wMyOgq2E0Q3LBuFo4E/WWYpGhSVW5g3C+yfkd2OTEemGVWvhvcBd1lmKRIUlmXPwwCD8XVHLaqPJ8fSM4zzMt85SFLrpnoBuujfEC4MwIy8bKGThJdhpVFxa2ttyhDTCkiwNVOH4ZiorgAnxo0V/j6Y8jJgKSzLj4MIuuN86h4VOuM9ntLtMkemSMAFdEo7IvBLMcja7LOXC0Fbud2K7zHDQNMKSLKxpgdOauawAHFSr8Al0aVg3FZZk4fLx8JR1iDzogicc/MA6R6h0SZiALgnrsmIU7DkuXiFU2LQD09PAOOssodEIS1Ll4VKV1auNg14Pc61zhEgjrAQ0wkpsQxV2a+T+eEXRA5Na4p2icrUrTd5phCVpuklltWXd8IKH31jnCI0KS9J0nXWAPIvgWusModElYQK6JExkzVromhxvkitb8CKM3g56ge2ts4RCIyxJyx0qq20b2j7+TuscIVFhSSpckz6Ck5TX65SICkvSssA6QCAetQ4QEhWWpGIQnrDOEIi/WQcIiQpLUtEGZesMIRjU65SICktSMQZWWGcIQTdUrDOERIUlaRm0DhCIpl7BIikVlqSiR3OLalKGHawzhESFJamIYLx1hkDodUpAhSVp0YYLtZlqHSAkKixJRQR7WGcIgYPdrTOERIUlaTnQOkAgplkHCIkKS9JyhHWAQOh1SkCrNSSg1RoSWTcIXd2wyjpIXvXBOBev1qBF/GqkEZakZbsITrQOkWcOPozKKhEVlqTGwVnWGXLuk9YBQqPCkjRN64VDrUPkUR/MBA62zhEaFZakKoKLve6VvooH5+Ab1jlCpMKStB1ZgVOsQ+RJP5wGHGWdI0T6yZeA3iWsj4PlG2B6N7xgncVaD0yO4GEHE6yzhEgjLEmdh4ktcKOHNussljy0tsANKqv6qbAkK0f0w/esQ1jx4MrwI+BI6ywhU2FJZjx8vA++a53DQgUucnC6dY7QqbAkUw7mlOFr1jmyVI7fEbzQOkcR6KZ7Arrp3lDfL8HZrsCvqQfXD9/xcL51lqLQCEusnFWBK3xBvwc9uArMVVk1lkZYCWiElYqfl+A0BxusgzSKh5Yy/MTBx6yzFM0o6wDS9E6uQOThFFeADRk8RBW4zsFJ1lmKqJDDcQnOSZWCTHkowyWorFKjwpK8+FQFzrYOMRIVmOPgXOscRaZ7WAnoHlbqBhwcVoIF1kGSKsP+wP+i7c1SpRGW5EmbhytDe+dwKO91qKxSF9Q3hjSF6RU42TpEEkOrLxxknaMZ6JIwAV0SZmZhCfYNYVLp0HyrJ4E9rbM0A42wJI/2rsQrcuZeP7wVlVVmVFiSSw5OsM5Qiyocb52hmaiwJJc8HGadoRaR9hXMlApLcsnDG6wz1CKUnEWhwpJccjDWOkONxlgHaCYqLMmrl60D1Gi1dYBmosKSXHKwyDpDjZ6xDtBMVFiSSx5us85Qo9utAzQTFZbkkXfwS+sQtYjgegKY4FoUKizJoxtCeQC6HR7ycLN1jmahR3MS0KM5mVg2CDNC2nS1D6ZGMN/DROssRacRluRJfxVOCKmsADphiYcPAiutsxSdCkvyYhEwqwvutw5Sjw6418XPFT5vnaXIVFhibb2Di9fBAR3wmHWYkSjBgkHY38OlwHrrPEWke1gJ6B5WQz3v4eoqXNENy6zDNFovTIng08CpwM7WeYpChZWACiuxAeKZ4P3AYmChg79W4dZO+KtttOyUYX8Hsz3sB+wNTAVKwI5Am2m4wPw/jPwThAZ68AwAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - addons.managed.openshift.io
+          resources:
+          - addons
+          - addons/status
+          - addons/finalizers
+          - addonoperators
+          - addonoperators/status
+          - addonoperators/finalizers
+          - addoninstances
+          - addoninstances/status
+          - addoninstances/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+        - apiGroups:
+          - addons.managed.openshift.io
+          resources:
+          - addonoperators
+          - addonoperators/status
+          - addonoperators/finalizers
+          - addoninstances
+          - addoninstances/status
+          - addoninstances/finalizers
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          - secrets
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - create
+          - update
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - operatorgroups
+          - catalogsources
+          - subscriptions
+          - installplans
+          verbs:
+          - create
+          - delete
+          - update
+          - watch
+          - get
+          - list
+          - patch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          - operators
+          verbs:
+          - watch
+          - get
+          - list
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - watch
+          - get
+          - list
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - update
+          - watch
+          - get
+          - list
+          - patch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - update
+          - watch
+          - get
+          - list
+          - patch
+        - apiGroups:
+          - monitoring.rhobs
+          resources:
+          - monitoringstacks
+          verbs:
+          - create
+          - delete
+          - update
+          - watch
+          - get
+          - list
+          - patch
+        - apiGroups:
+          - package-operator.run
+          resources:
+          - clusterobjecttemplates
+          verbs:
+          - create
+          - delete
+          - update
+          - watch
+          - get
+          - list
+          - patch
+        serviceAccountName: addon-operator
+      deployments:
+      - name: addon-operator-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: addon-operator
+          strategy: {}
+          template:
+            metadata:
+              creationTimestamp: null
+              labels:
+                app.kubernetes.io/name: addon-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/infra
+                        operator: Exists
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --tls-cert-file=/tmp/k8s-metrics-server/serving-certs/tls.crt
+                - --tls-private-key-file=/tmp/k8s-metrics-server/serving-certs/tls.key
+                - --logtostderr=true
+                - --ignore-paths=/metrics,/healthz
+                image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
+                livenessProbe:
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                  tcpSocket:
+                    port: 8443
+                name: metrics-relay-server
+                ports:
+                - containerPort: 8443
+                readinessProbe:
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  tcpSocket:
+                    port: 8443
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 30Mi
+                  requests:
+                    cpu: 100m
+                    memory: 30Mi
+                volumeMounts:
+                - mountPath: /tmp/k8s-metrics-server/serving-certs/
+                  name: tls
+                  readOnly: true
+              - args:
+                - --enable-leader-election
+                env:
+                - name: ENABLE_STATUS_REPORTING
+                  value: "true"
+                image: quay.io/openshift/addon-operator:latest
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 600Mi
+                  requests:
+                    cpu: 100m
+                    memory: 300Mi
+                volumeMounts:
+                - mountPath: /etc/pki/ca-trust/extracted/pem
+                  name: trusted-ca-bundle
+                  readOnly: true
+              serviceAccountName: addon-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/infra
+              volumes:
+              - name: tls
+                secret:
+                  secretName: metrics-server-cert
+              - configMap:
+                  defaultMode: 420
+                  items:
+                  - key: ca-bundle.crt
+                    path: tls-ca-bundle.pem
+                  name: trusted-ca-bundle
+                  optional: true
+                name: trusted-ca-bundle
+      - name: addon-operator-webhooks
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: addon-operator-webhook-server
+          strategy:
+            rollingUpdate:
+              maxSurge: 25%
+              maxUnavailable: 1
+            type: RollingUpdate
+          template:
+            metadata:
+              creationTimestamp: null
+              labels:
+                app.kubernetes.io/name: addon-operator-webhook-server
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/infra
+                        operator: Exists
+                podAntiAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                  - labelSelector:
+                      matchExpressions:
+                      - key: app.kubernetes.io/name
+                        operator: In
+                        values:
+                        - addon-operator-webhook-server
+                    topologyKey: kubernetes.io/hostname
+              containers:
+              - image: quay.io/openshift/addon-operator-webhook:latest
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: webhook
+                ports:
+                - containerPort: 8080
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 50Mi
+                  requests:
+                    cpu: 100m
+                    memory: 30Mi
+              serviceAccountName: addon-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/infra
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        serviceAccountName: addon-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: AllNamespaces
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  keywords:
+  - addons
+  - managed
+  links:
+  - name: Source Code
+    url: https://github.com/openshift/addon-operator
+  maintainers:
+  - email: sd-mt-sre@redhat.com
+    name: Red Hat Service Delivery - Managed Tenants Team
+  maturity: stable
+  provider:
+    name: Red Hat
+    url: www.redhat.com
+  version: 1.13.9
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: addon-operator-webhooks
+    failurePolicy: Fail
+    generateName: vaddons.managed.openshift.io
+    rules:
+    - apiGroups:
+      - addons.managed.openshift.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - addons
+    sideEffects: None
+    targetPort: 8080
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-addon
+status:
+  cleanup: {}

--- a/deploy-extras/package/hcp/addon-operator.yaml
+++ b/deploy-extras/package/hcp/addon-operator.yaml
@@ -22,52 +22,15 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --tls-cert-file=/tmp/k8s-metrics-server/serving-certs/tls.crt
-        - --tls-private-key-file=/tmp/k8s-metrics-server/serving-certs/tls.key
-        - --logtostderr=true
-        - --kubeconfig=/etc/openshift/kubeconfig/kubeconfig
-        - --ignore-paths=/metrics,/healthz
-        env:
-        - name: KUBECONFIG
-          value: /etc/openshift/kubeconfig/kubeconfig
-        image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
-        livenessProbe:
-          initialDelaySeconds: 15
-          periodSeconds: 20
-          tcpSocket:
-            port: 8443
-        name: metrics-relay-server
-        ports:
-        - containerPort: 8443
-        readinessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          tcpSocket:
-            port: 8443
-        resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
-          requests:
-            cpu: 100m
-            memory: 30Mi
-        volumeMounts:
-        - mountPath: /tmp/k8s-metrics-server/serving-certs/
-          name: tls
-          readOnly: true
-        - mountPath: /etc/openshift/kubeconfig
-          name: kubeconfig
-          readOnly: true
-      - args:
         - --enable-leader-election
+        - --metrics-addr=:8443
+        - --metrics-tls-dir=/etc/tls/manager/metrics
         env:
         - name: KUBECONFIG
           value: /etc/openshift/kubeconfig/kubeconfig
         - name: ADDON_OPERATOR_NAMESPACE
           value: addon-operator
-        image: quay.io/app-sre/addon-operator-manager:0aae408
+        image: quay.io/app-sre/addon-operator-manager:17c5c95
         livenessProbe:
           httpGet:
             path: /healthz
@@ -75,6 +38,8 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
+        ports:
+        - containerPort: 8443
         readinessProbe:
           httpGet:
             path: /readyz
@@ -92,12 +57,14 @@ spec:
         - mountPath: /etc/openshift/kubeconfig
           name: kubeconfig
           readOnly: true
+        - mountPath: /etc/tls/manager/metrics
+          name: manager-metrics-tls
       volumes:
       - name: kubeconfig
         secret:
           defaultMode: 420
           secretName: service-network-admin-kubeconfig
-      - name: tls
+      - name: manager-metrics-tls
         secret:
-          secretName: metrics-server-cert
+          secretName: manager-metrics-tls
 status: {}


### PR DESCRIPTION
With the Addon Operator adopting Boilerplate and subscribing to the [golang-osd-operator](https://github.com/openshift/boilerplate/tree/master/boilerplate/openshift/golang-osd-operator) convention, Boilerplate already offers a few standard Make [targets](https://github.com/openshift/boilerplate/blob/master/boilerplate/openshift/golang-osd-operator/standard.mk)
We will have to go through ADO's existing Makefile targets and make sure they do not overlap with the targets present in the Boilerplate convention.

Closes: #[MTSRE-1582](https://issues.redhat.com/browse/MTSRE-1582)