### PR TITLE
MTSRE-841: Collect ocm client request reconcile error,

### DIFF
--- a/cmd/api-mock/main.go
+++ b/cmd/api-mock/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/openshift/addon-operator/internal/ocm"
 	"github.com/openshift/addon-operator/internal/ocm/ocmtest"
 )
 
@@ -36,6 +37,7 @@ func main() {
 		"/api/addons_mgmt/v1/clusters/{cluster_id}/status",
 		NewAddonStatusCreateEndpoint(addonStatusStore),
 	)
+	r.HandleFunc("/configure", configure).Methods(http.MethodPatch)
 
 	addr := ":8080"
 	log.Printf("listening on %s\n", addr)
@@ -164,6 +166,28 @@ func (a *AddonStatusCreateEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Req
 			log.Printf("reading request body: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintln(w, `{}`)
+			return
+		}
+
+		if apiMockConfig.FailOnAddonStatusCreateEndpoint {
+			log.Println("Fail on addon status create endpoint")
+			resp, err := json.Marshal(
+				ocm.OCMError{
+					StatusCode: http.StatusBadRequest,
+					Code:       "OCM-MGMT",
+					Reason:     "mock failure on addon status create endpoint",
+				},
+			)
+			if err != nil {
+				log.Printf("Failed to marshal OCMError: %v", err)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			if _, err = w.Write(resp); err != nil {
+				log.Printf("Failed to write response body: %v", err)
+				return
+			}
 			return
 		}
 		// unmarshal payload.
@@ -341,4 +365,29 @@ func unmarshalPayloadToAddonStatus(data []byte) (addonStatus, error) {
 		return addonStatus{}, err
 	}
 	return status, nil
+}
+
+type APIMockConfig struct {
+	FailOnAddonStatusCreateEndpoint bool `json:"failOnAddonStatusCreateEndpoint"`
+}
+
+var apiMockConfig = APIMockConfig{
+	FailOnAddonStatusCreateEndpoint: false,
+}
+
+// Configures this api mock server on-the-fly
+func configure(w http.ResponseWriter, r *http.Request) {
+	decoder := json.NewDecoder(r.Body)
+
+	var conf APIMockConfig
+
+	if err := decoder.Decode(&conf); err != nil {
+		fmt.Printf("Failed to decode config: %v\n", err)
+		w.WriteHeader(http.StatusBadRequest)
+	} else {
+		fmt.Printf("Patching server with: %v\n", conf)
+		if conf.FailOnAddonStatusCreateEndpoint {
+			apiMockConfig.FailOnAddonStatusCreateEndpoint = conf.FailOnAddonStatusCreateEndpoint
+		}
+	}
 }

--- a/controllers/errors.go
+++ b/controllers/errors.go
@@ -11,6 +11,8 @@ var (
 	ErrGetAddon = errors.New("err_get_addon")
 	// An error happened while syncing with external APIs
 	ErrSyncWithExternalAPIs = errors.New("err_sync_with_external_apis")
+	// An OCM client request error was encountred
+	ErrOCMClientRequest = errors.New("err_ocm_client_request")
 	// Failed to update an addon
 	ErrUpdateAddon = errors.New("err_update_addon")
 	// Failed to notify addon

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20211105201321-411021ada9ab
 	github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring v0.68.0-rhobs2
 	github.com/rhobs/observability-operator v0.0.25
+	github.com/sethvargo/go-retry v0.2.4
 	github.com/stretchr/testify v1.8.4
 	k8s.io/api v0.28.3
 	k8s.io/apiextensions-apiserver v0.28.3

--- a/go.sum
+++ b/go.sum
@@ -1259,6 +1259,8 @@ github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvW
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sethvargo/go-retry v0.2.4 h1:T+jHEQy/zKJf5s95UkguisicE0zuF9y7+/vgz08Ocec=
+github.com/sethvargo/go-retry v0.2.4/go.mod h1:1afjQuvh7s4gflMObvjLPaWgluLLyhA1wmVZ6KLpICw=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=

--- a/integration/metrics_collection_test.go
+++ b/integration/metrics_collection_test.go
@@ -1,0 +1,198 @@
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sethvargo/go-retry"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	addonsv1alpha1 "github.com/openshift/addon-operator/api/v1alpha1"
+	"github.com/openshift/addon-operator/controllers"
+	"github.com/openshift/addon-operator/integration"
+	"github.com/openshift/addon-operator/internal/testutil"
+)
+
+// Tests that reconcile error metrics are collected
+func (s *integrationTestSuite) TestReconcileErrorMetrics() {
+	if !testutil.IsApiMockEnabled() {
+		s.T().Skip("skipping OCM tests since api mock execution is disabled")
+	}
+
+	ctx := context.Background()
+	addon := addon_OwnNamespace()
+
+	// 1. Configure api mock to return an error
+	// on creating OCM endpoints for addon status
+	err := configureApiMock(ctx, true)
+	s.Require().NoError(err)
+
+	// 2. Patch ADO so it uses the ocm client/api
+	var ado1 addonsv1alpha1.AddonOperator
+	err = integration.Client.Get(ctx, client.ObjectKey{
+		Name:      "addon-operator",
+		Namespace: integration.AddonOperatorNamespace,
+	}, &ado1)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(ado1.Name)
+
+	ado2 := ado1.DeepCopy()
+	ado2.Spec.OCM = &addonsv1alpha1.AddonOperatorOCM{
+		Endpoint: "http://api-mock.api-mock.svc.cluster.local",
+		Secret: addonsv1alpha1.ClusterSecretReference{
+			Name:      "pull-secret",
+			Namespace: "api-mock",
+		},
+	}
+	err = integration.Client.Patch(ctx, ado2, client.MergeFrom(&ado1))
+	s.Require().NoError(err)
+
+	// 3. Create an addon
+	err = integration.Client.Create(ctx, addon)
+	s.Require().NoError(err)
+	s.T().Cleanup(func() {
+		// Ensure cleanup of addon
+		s.addonCleanup(addon, ctx)
+		// Ensure to reset api-mock setting
+		err = configureApiMock(ctx, false)
+		s.Require().NoError(err)
+	})
+
+	// 4. Wait for addon to be created
+	err = integration.WaitForObject(
+		ctx,
+		s.T(), defaultAddonAvailabilityTimeout, addon, "to be Available",
+		func(obj client.Object) (done bool, err error) {
+			a := obj.(*addonsv1alpha1.Addon)
+			return meta.IsStatusConditionTrue(
+				a.Status.Conditions, addonsv1alpha1.Available), nil
+		})
+	s.Require().NoError(err)
+
+	// 5. Get addon-operator-manager pod
+	adoPods := &corev1.PodList{}
+	err = integration.Client.List(
+		ctx,
+		adoPods,
+		client.InNamespace(integration.AddonOperatorNamespace),
+	)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(adoPods, "No ADO pods found while listing")
+
+	var adoPod corev1.Pod
+	for _, pod := range adoPods.Items {
+		if strings.HasPrefix(pod.Name, "addon-operator-manager") {
+			adoPod = pod
+			break
+		}
+	}
+	s.Require().NotEmpty(adoPod.Name, "ADO pod not found")
+
+	backoff := retry.NewConstant(time.Minute)
+	err = retry.Do(
+		ctx,
+		retry.WithMaxDuration(time.Minute*10, backoff),
+		func(ctx context.Context) error {
+			metricNotFound := errors.New("expected addon_operator metric was not found")
+			podCommand1 := []string{"curl", "https://localhost:8443/metrics", "-k"}
+			// nolint:contextcheck
+			result, _, err := integration.ExecCommandInPod(
+				integration.AddonOperatorNamespace,
+				adoPod.Name,
+				"manager",
+				podCommand1,
+			)
+			if err != nil {
+				// Try http if https doesn't work for local dev
+				podCommand2 := []string{"curl", "http://localhost:8443/metrics"}
+				// nolint:contextcheck
+				result, _, err = integration.ExecCommandInPod(
+					integration.AddonOperatorNamespace,
+					adoPod.Name,
+					"manager",
+					podCommand2,
+				)
+			}
+
+			// 5.1 Ensure ErrOCMClientRequest error was recorded due to
+			// the mock OCM API error instrumented previously.
+			if strings.Contains(result, controllers.ErrOCMClientRequest.Error()) {
+				return err
+			}
+			return retry.RetryableError(metricNotFound)
+		})
+	s.Require().NoError(err)
+}
+
+func getAPIMockPod(ctx context.Context) (corev1.Pod, error) {
+	var apiMockPod corev1.Pod
+	pods := &corev1.PodList{}
+	err := integration.Client.List(
+		ctx,
+		pods,
+		client.InNamespace("api-mock"),
+	)
+	if err != nil {
+		return apiMockPod, err
+	}
+	for _, pod := range pods.Items {
+		if strings.HasPrefix(pod.Name, "api-mock") {
+			apiMockPod = pod
+			break
+		}
+	}
+	return apiMockPod, err
+}
+
+type APIMockConfig struct {
+	FailOnAddonStatusCreateEndpoint bool `json:"failOnAddonStatusCreateEndpoint"`
+}
+
+func configureApiMock(ctx context.Context, failOnAddonStatusCreateEndpoint bool) error {
+	apiMockPod, err := getAPIMockPod(ctx)
+	if err != nil {
+		return err
+	}
+	config := &APIMockConfig{
+		FailOnAddonStatusCreateEndpoint: failOnAddonStatusCreateEndpoint,
+	}
+	payload, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %v\n", config)
+	}
+	podCommand := []string{
+		"curl",
+		"-X",
+		"PATCH",
+		"-H",
+		"Content-Type: application/json",
+		"-d",
+		string(payload),
+		"http://api-mock/configure",
+		"-k",
+	}
+	backoff := retry.NewConstant(time.Second * 10)
+	err = retry.Do(
+		ctx,
+		retry.WithMaxDuration(time.Minute*1, backoff),
+		func(ctx context.Context) error {
+			// nolint:contextcheck
+			_, _, err := integration.ExecCommandInPod(
+				"api-mock",
+				apiMockPod.Name,
+				apiMockPod.Spec.Containers[0].Name,
+				podCommand,
+			)
+			if err != nil {
+				return retry.RetryableError(err)
+			}
+			return err
+		})
+	return err
+}

--- a/magefiles/development.go
+++ b/magefiles/development.go
@@ -133,6 +133,15 @@ func (d Dev) Integration(ctx context.Context) error {
 	return nil
 }
 
+// Support running of single test cases for local dev only.
+func (d Dev) IntegrationRun(ctx context.Context, testName string) error {
+	mg.SerialDeps(
+		Dev.Deploy,
+	)
+	mg.SerialDeps(mg.F(Test.IntegrationRun, testName))
+	return nil
+}
+
 func (d Dev) LoadImage(image string) error {
 	mg.Deps(
 		mg.F(Build.ImageBuild, image),


### PR DESCRIPTION
### What type of PR is this?
bug and feature


### What this PR does / why we need it?

1. Collects OCM client request error metric
2. Creates integration test for reconcile error metric collection
3. Modifies the API mock server to allow a mocked OCM API request failure
4. Enables running of a single integration test case

### Which Jira/Github issue(s) this PR fixes?

Fixes [MTSRE-1572](https://issues.redhat.com//browse/MTSRE-1572) #[MTSRE-841](https://issues.redhat.com/browse/MTSRE-841)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make test-unit` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR
- [ ] Squashed your commits
