### PR TITLE
fix: Remove redundant yaml split in CRDs

### DIFF
--- a/deploy/crds/addons.managed.openshift.io_addoninstances.yaml
+++ b/deploy/crds/addons.managed.openshift.io_addoninstances.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/crds/addons.managed.openshift.io_addonoperators.yaml
+++ b/deploy/crds/addons.managed.openshift.io_addonoperators.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/crds/addons.managed.openshift.io_addons.yaml
+++ b/deploy/crds/addons.managed.openshift.io_addons.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
### What type of PR is this?
Refactor

### What this PR does / why we need it?
Removes redundant YAML split in CRDs which is causing `opm` to assume each CRDs has multiple YAML manifests within.
