### PR TITLE
fix: Temporarily disable make-generate pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,11 +50,12 @@ repos:
     pass_filenames: false
     always_run: true
 
-  - id: make-generate
-    name: make-generate
-    entry: make generate
-    language: system
-    exclude: ".*"
-    pass_filenames: false
-    always_run: true
-    require_serial: true # mage does not like multiple parallel compiles
+# Temporarily disabling make-generate
+  # - id: make-generate
+  #   name: make-generate
+  #   entry: make generate
+  #   language: system
+  #   exclude: ".*"
+  #   pass_filenames: false
+  #   always_run: true
+  #   require_serial: true # mage does not like multiple parallel compiles


### PR DESCRIPTION
### What type of PR is this?
Bug


### What this PR does / why we need it?
When we run `make generate` it appends `---` to the top of the CRD files making it non-consumable by `opm`, this PR temporarily disables it until we subscribe to Boilerplate and leverage it `generate` target.
