### PR TITLE
MTSRE-1628: Ignore unclassified/undefined reconcile errors from metri…

### DIFF
--- a/controllers/addon/addon_controller_test.go
+++ b/controllers/addon/addon_controller_test.go
@@ -32,7 +32,7 @@ type reconcileErrorTestCase struct {
 
 var (
 	_                   addonReconciler = (*mockSubReconciler)(nil)
-	errMockSubReconcile                 = errors.New("failed to reconcile")
+	errMockSubReconcile                 = controllers.ErrGetAddon
 )
 
 type mockSubReconciler struct {

--- a/controllers/addon/addon_controller_test.go
+++ b/controllers/addon/addon_controller_test.go
@@ -119,7 +119,7 @@ func TestReconcileErrorHandling(t *testing.T) {
 		}
 
 		if testCase.externalAPISyncErrPresent {
-			ocmClient.On("PostAddOnStatus", mock.Anything, mock.Anything, mock.Anything).Return(ocm.AddOnStatusResponse{}, errors.New("gateway timeout"))
+			ocmClient.On("PostAddOnStatus", mock.Anything, mock.Anything, mock.Anything).Return(ocm.AddOnStatusResponse{}, controllers.ErrSyncWithExternalAPIs)
 		} else {
 			ocmClient.On("PostAddOnStatus", mock.Anything, mock.Anything, mock.Anything).Return(ocm.AddOnStatusResponse{}, nil)
 		}

--- a/controllers/errors.go
+++ b/controllers/errors.go
@@ -24,9 +24,9 @@ var (
 	// Failed to get an addon
 	ErrGetAddon = newControllerReconcileError("err_get_addon")
 	// An error happened while syncing with external APIs
-	ErrSyncWithExternalAPIs = errors.New("err_sync_with_external_apis")
+	ErrSyncWithExternalAPIs = newControllerReconcileError("err_sync_with_external_apis")
 	// An OCM client request error was encountred
-	ErrOCMClientRequest = errors.New("err_ocm_client_request")
+	ErrOCMClientRequest = newControllerReconcileError("err_ocm_client_request")
 	// Failed to update an addon
 	ErrUpdateAddon = newControllerReconcileError("err_update_addon")
 	// Failed to notify addon

--- a/controllers/errors.go
+++ b/controllers/errors.go
@@ -2,71 +2,85 @@ package controllers
 
 import "errors"
 
+type ControllerReconcileError struct {
+	Reason string
+}
+
+func newControllerReconcileError(reason string) *ControllerReconcileError {
+	return &ControllerReconcileError{
+		Reason: reason,
+	}
+}
+
+func (c *ControllerReconcileError) Error() string {
+	return c.Reason
+}
+
 var (
 	// This error is returned when a reconciled child object already
 	// exists and is not owned by the current controller/addon
 	ErrNotOwnedByUs = errors.New("object is not owned by us")
 
 	// Failed to get an addon
-	ErrGetAddon = errors.New("err_get_addon")
+	ErrGetAddon = newControllerReconcileError("err_get_addon")
 	// An error happened while syncing with external APIs
 	ErrSyncWithExternalAPIs = errors.New("err_sync_with_external_apis")
 	// An OCM client request error was encountred
 	ErrOCMClientRequest = errors.New("err_ocm_client_request")
 	// Failed to update an addon
-	ErrUpdateAddon = errors.New("err_update_addon")
+	ErrUpdateAddon = newControllerReconcileError("err_update_addon")
 	// Failed to notify addon
-	ErrNotifyAddon = errors.New("err_notify_addon")
+	ErrNotifyAddon = newControllerReconcileError("err_notify_addon")
 	// Failed to receive ack from addon
-	ErrAckReceivedFromAddon = errors.New("err_ack_received_from_addon")
+	ErrAckReceivedFromAddon = newControllerReconcileError("err_ack_received_from_addon")
 	// Failed to ensure creation of addoninstance
-	ErrEnsureCreateAddonInstance = errors.New("err_ensure_create_addoninstance")
+	ErrEnsureCreateAddonInstance = newControllerReconcileError("err_ensure_create_addoninstance")
 	// Failed to ensure creation of servicemonitor
-	ErrEnsureCreateServiceMonitor = errors.New("err_ensure_servicemonitor")
+	ErrEnsureCreateServiceMonitor = newControllerReconcileError("err_ensure_servicemonitor")
 	// Failed to ensure deletion of servicemonitor
-	ErrEnsureDeleteServiceMonitor = errors.New("err_ensure_delete_servicemonitor")
+	ErrEnsureDeleteServiceMonitor = newControllerReconcileError("err_ensure_delete_servicemonitor")
 	// Failed to ensure creation of monitoringstack
-	ErrEnsureCreateMonitoringStack = errors.New("err_ensure_create_monitoringstack")
+	ErrEnsureCreateMonitoringStack = newControllerReconcileError("err_ensure_create_monitoringstack")
 	// Failed to ensure creation of namespace
-	ErrEnsureCreateNamespace = errors.New("err_ensure_create_namespace")
+	ErrEnsureCreateNamespace = newControllerReconcileError("err_ensure_create_namespace")
 	// Failed to ensure deletion of namespace
-	ErrEnsureDeleteNamespace = errors.New("err_ensure_delete_namespace")
+	ErrEnsureDeleteNamespace = newControllerReconcileError("err_ensure_delete_namespace")
 	// Failed to ensure existence of operator group
-	ErrEnsureOperatorGroup = errors.New("err_ensure_operator_group")
+	ErrEnsureOperatorGroup = newControllerReconcileError("err_ensure_operator_group")
 	// Failed to ensure existence of networkpolicy
-	ErrEnsureNetworkPolicy = errors.New("err_ensure_networkpolicy")
+	ErrEnsureNetworkPolicy = newControllerReconcileError("err_ensure_networkpolicy")
 	// Failed to ensure existence of catalogsource
-	ErrEnsureCatalogSource = errors.New("err_ensure_catalogsource")
+	ErrEnsureCatalogSource = newControllerReconcileError("err_ensure_catalogsource")
 	// Failed to ensure existence of additional catalogsource
-	ErrEnsureAdditionalCatalogSource = errors.New("err_ensure_additional_catalogsource")
+	ErrEnsureAdditionalCatalogSource = newControllerReconcileError("err_ensure_additional_catalogsource")
 	// An error happened while reconciling a subscription
-	ErrReconcileSubscription = errors.New("err_reconcile_subscription")
+	ErrReconcileSubscription = newControllerReconcileError("err_reconcile_subscription")
 	// An error happened while observing a CSV
-	ErrObserveCSV = errors.New("err_observe_csv")
+	ErrObserveCSV = newControllerReconcileError("err_observe_csv")
 	// Failed to ensure deletion of clusterobjecttemplate
-	ErrEnsureDeleteClusterObjectTemplate = errors.New("err_ensure_delete_of_clusterobjecttemplate")
+	ErrEnsureDeleteClusterObjectTemplate = newControllerReconcileError("err_ensure_delete_of_clusterobjecttemplate")
 	// An error happened while reconcileing clusterobjecttemplate
-	ErrReconcileClusterObjectTemplate = errors.New("err_reconcile_cluster_object_template")
+	ErrReconcileClusterObjectTemplate = newControllerReconcileError("err_reconcile_cluster_object_template")
 	// Failed to cleanup unknown secrets
-	ErrCleanupUnknownSecrets = errors.New("err_cleanup_unknown_secrets")
+	ErrCleanupUnknownSecrets = newControllerReconcileError("err_cleanup_unknown_secrets")
 	// Failed to get target/destination secrets that didn't have namespace
-	ErrGetDestinationSecretsWithoutNamespace = errors.New("err_get_destination_secrets_without_namespace")
+	ErrGetDestinationSecretsWithoutNamespace = newControllerReconcileError("err_get_destination_secrets_without_namespace")
 	// Failed reconcile secrets in addon namespaces
-	ErrReconcileSecretsInAddonNamespaces = errors.New("err_reconcile_secrets_in_addon_namespaces")
+	ErrReconcileSecretsInAddonNamespaces = newControllerReconcileError("err_reconcile_secrets_in_addon_namespaces")
 	// Failed to get addoninstance
-	ErrGetAddonInstance = errors.New("err_get_addoninstance")
+	ErrGetAddonInstance = newControllerReconcileError("err_get_addoninstance")
 	// Failed to update addoninstance status
-	ErrUpdateAddonInstanceStatus = errors.New("err_update_addon_instance_status")
+	ErrUpdateAddonInstanceStatus = newControllerReconcileError("err_update_addon_instance_status")
 	// Failed to execute addoninstance reconcile phase
-	ErrExecuteAddonInstanceReconcilePhase = errors.New("err_execute_addon_instance_reconcile_phase")
+	ErrExecuteAddonInstanceReconcilePhase = newControllerReconcileError("err_execute_addon_instance_reconcile_phase")
 	// Failed to get default addonoperator
-	ErrGetDefaultAddonOperator = errors.New("err_get_default_addon_operator")
+	ErrGetDefaultAddonOperator = newControllerReconcileError("err_get_default_addon_operator")
 	// Failed to create addonoperator
-	ErrCreateAddonOperator = errors.New("err_create_addon_operator")
+	ErrCreateAddonOperator = newControllerReconcileError("err_create_addon_operator")
 	// Failed to handle global pause of addon-operator
-	ErrAddonOperatorHandleGlobalPause = errors.New("err_addon_operator_handle_global_pause")
+	ErrAddonOperatorHandleGlobalPause = newControllerReconcileError("err_addon_operator_handle_global_pause")
 	// Failed to create OCM client
-	ErrCreateOCMClient = errors.New("err_create_ocm_client")
+	ErrCreateOCMClient = newControllerReconcileError("err_create_ocm_client")
 	// Failed to report addon-operator readiness status
-	ErrReportAddonOperatorStatus = errors.New("err_report_addonoperator_status")
+	ErrReportAddonOperatorStatus = newControllerReconcileError("err_report_addonoperator_status")
 )


### PR DESCRIPTION
### What type of PR is this?
_bug_


### What this PR does / why we need it?
Reconcile errors are returned or can be returned anywhere in the ADO code. Some reconcile errors are not of interest with respect to monitoring, therefore ignore them.

This PR adds a type check for reconcile errors returned and so to ensure they are the ones defined only. Additionally, this PR updates the associated unit tests.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[MTSRE-1628](https://issues.redhat.com//browse/MTSRE-1628)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make test-unit` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR
- [ ] Squashed your commits
