### PR TITLE
Deprecate metrics-relay-server from ADO package

### DIFF
--- a/deploy-extras/package/hcp/addon-operator.yaml
+++ b/deploy-extras/package/hcp/addon-operator.yaml
@@ -22,46 +22,9 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --tls-cert-file=/tmp/k8s-metrics-server/serving-certs/tls.crt
-        - --tls-private-key-file=/tmp/k8s-metrics-server/serving-certs/tls.key
-        - --logtostderr=true
-        - --kubeconfig=/etc/openshift/kubeconfig/kubeconfig
-        - --ignore-paths=/metrics,/healthz
-        env:
-        - name: KUBECONFIG
-          value: /etc/openshift/kubeconfig/kubeconfig
-        image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
-        livenessProbe:
-          initialDelaySeconds: 15
-          periodSeconds: 20
-          tcpSocket:
-            port: 8443
-        name: metrics-relay-server
-        ports:
-        - containerPort: 8443
-        readinessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          tcpSocket:
-            port: 8443
-        resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
-          requests:
-            cpu: 100m
-            memory: 30Mi
-        volumeMounts:
-        - mountPath: /tmp/k8s-metrics-server/serving-certs/
-          name: tls
-          readOnly: true
-        - mountPath: /etc/openshift/kubeconfig
-          name: kubeconfig
-          readOnly: true
-      - args:
         - --enable-leader-election
+        - --metrics-addr=:8443
+        - --metrics-tls-dir=/etc/tls/manager/metrics
         env:
         - name: KUBECONFIG
           value: /etc/openshift/kubeconfig/kubeconfig
@@ -92,12 +55,13 @@ spec:
         - mountPath: /etc/openshift/kubeconfig
           name: kubeconfig
           readOnly: true
+        - mountPath: /etc/tls/manager/metrics
+          name: manager-metrics-tls
       volumes:
       - name: kubeconfig
         secret:
           defaultMode: 420
           secretName: service-network-admin-kubeconfig
-      - name: tls
+      - name: manager-metrics-tls
         secret:
-          secretName: metrics-server-cert
-status: {}
+          secretName: manager-metrics-tls

--- a/hack/build-deploy.sh
+++ b/hack/build-deploy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# AppSRE CD
+
+set -exv
+
+make -C $(dirname $0)/../ build-package-push

--- a/hack/build-package.sh
+++ b/hack/build-package.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+usage() {
+    echo "Usage: $0 IMAGE_URI" >&2
+    exit 1
+}
+
+## image_exists_in_repo IMAGE_URI
+#
+# Checks whether IMAGE_URI -- e.g. quay.io/app-sre/osd-metrics-exporter:abcd123
+# -- exists in the remote repository.
+# If so, returns success.
+# If the image does not exist, but the query was otherwise successful, returns
+# failure.
+# If the query fails for any reason, prints an error and *exits* nonzero.
+#
+# This function cribbed from:
+# https://github.com/openshift/boilerplate/blob/0ba6566d544d0df9993a92b2286c131eb61f3e88/boilerplate/_lib/common.sh#L77-L135
+image_exists_in_repo() {
+    local image_uri=$1
+    local output
+    local rc
+
+    local skopeo_stderr=$(mktemp)
+
+    output=$(skopeo inspect docker://${image_uri} 2>$skopeo_stderr)
+    rc=$?
+    # So we can delete the temp file right away...
+    stderr=$(cat $skopeo_stderr)
+    rm -f $skopeo_stderr
+    if [[ $rc -eq 0 ]]; then
+        # The image exists. Sanity check the output.
+        local digest=$(echo $output | jq -r .Digest)
+        if [[ -z "$digest" ]]; then
+            echo "Unexpected error: skopeo inspect succeeded, but output contained no .Digest"
+            echo "Here's the output:"
+            echo "$output"
+            echo "...and stderr:"
+            echo "$stderr"
+            exit 1
+        fi
+        echo "Image ${image_uri} exists with digest $digest."
+        return 0
+    elif [[ "$stderr" == *"manifest unknown"* ]]; then
+        # We were able to talk to the repository, but the tag doesn't exist.
+        # This is the normal "green field" case.
+        echo "Image ${image_uri} does not exist in the repository."
+        return 1
+    elif [[ "$stderr" == *"was deleted or has expired"* ]]; then
+        # This should be rare, but accounts for cases where we had to
+        # manually delete an image.
+        echo "Image ${image_uri} was deleted from the repository."
+        echo "Proceeding as if it never existed."
+        return 1
+    else
+        # Any other error. For example:
+        #   - "unauthorized: access to the requested resource is not
+        #     authorized". This happens not just on auth errors, but if we
+        #     reference a repository that doesn't exist.
+        #   - "no such host".
+        #   - Network or other infrastructure failures.
+        # In all these cases, we want to bail, because we don't know whether
+        # the image exists (and we'd likely fail to push it anyway).
+        echo "Error querying the repository for ${image_uri}:"
+        echo "stdout: $output"
+        echo "stderr: $stderr"
+        exit 1
+    fi
+}
+
+set -exv
+
+IMAGE_URI=$1
+[[ -z "$IMAGE_URI" ]] && usage
+
+# NOTE(efried): Since we reference images by digest, rebuilding an image
+# with the same tag can be Bad. This is because the digest calculation
+# includes metadata such as date stamp, meaning that even though the
+# contents may be identical, the digest may change. In this situation,
+# the original digest URI no longer has any tags referring to it, so the
+# repository deletes it. This can break existing deployments referring
+# to the old digest. We could have solved this issue by generating a
+# permanent tag tied to each digest. We decided to do it this way
+# instead.
+# For testing purposes, if you need to force the build/push to rerun,
+# delete the image at $IMAGE_URI.
+if image_exists_in_repo "$IMAGE_URI"; then
+    echo "Image ${IMAGE_URI} already exists. Nothing to do!"
+    exit 0
+fi
+
+# build the image and push the image
+make -C $(dirname $0)/../ build-package skopeo-push-package


### PR DESCRIPTION
### What type of PR is this?
Refactor

### What this PR does / why we need it?
- Following https://issues.redhat.com/browse/MTSRE-1518 changes were made in ADO for the addon-operator-manager to drop the metrics-relay-server container but updating the ADO package was missed. This PR follows it.
- Mage functionality isn't supported by the AppSRE pipeline as it doesn't yet support Go 1.20, hence we'll have to fallback to using shell-based build & deploy scripts for ADO package.