### PR TITLE
use podscheduled reason for addon health info

### DIFF
--- a/bundle/manifests/addon-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/addon-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2023-12-14T12:18:13Z"
+    createdAt: "2023-12-15T04:26:20Z"
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   creationTimestamp: null
@@ -68,6 +68,7 @@ spec:
           resources:
           - namespaces
           - secrets
+          - pods
           verbs:
           - create
           - get

--- a/controllers/addon/addon_controller.go
+++ b/controllers/addon/addon_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,6 +20,8 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,6 +66,18 @@ type AddonReconciler struct {
 	// in the order in which they appear in this slice.
 	subReconcilers []addonReconciler
 }
+
+type addonHealth struct {
+	reason string
+}
+
+func (a addonHealth) GetReason() string {
+	return a.reason
+}
+
+var (
+	UnschedulableAddonPod = addonHealth{reason: "UnschedulableAddonPod"}
+)
 
 type addonReconciler interface {
 	Reconcile(ctx context.Context, addon *addonsv1alpha1.Addon) (ctrl.Result, error)
@@ -293,10 +308,10 @@ func (r *AddonReconciler) Reconcile(
 
 	reconcileResult, reconcileErr := r.reconcile(ctx, addon, logger)
 
-	// Update metrics only if a Recorder is initialized
-	if r.Recorder != nil {
-		r.Recorder.RecordAddonMetrics(addon)
+	if err := r.recordAddonMetrics(ctx, addon); err != nil {
+		r.Log.Error(err, "failed to record addon metrics")
 	}
+
 	multiErr := r.syncWithExternalAPIs(ctx, logger, addon)
 
 	if multiErr.ErrorOrNil() != nil {
@@ -401,4 +416,81 @@ func (r *AddonReconciler) reconcile(ctx context.Context, addon *addonsv1alpha1.A
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// Lists and filters pods with corev1.PodReasonUnschedulable status
+func (r *AddonReconciler) listUnschedulableAddonPods(
+	ctx context.Context,
+	addon *addonsv1alpha1.Addon,
+) (*corev1.PodList, error) {
+	addonPods := &corev1.PodList{}
+	unschedulablePods := &corev1.PodList{}
+
+	var targetNs string
+	switch addon.Spec.Install.Type {
+	case addonsv1alpha1.OLMAllNamespaces:
+		if addon.Spec.Install.OLMAllNamespaces != nil {
+			targetNs = addon.Spec.Install.OLMAllNamespaces.Namespace
+		}
+	case addonsv1alpha1.OLMOwnNamespace:
+		if addon.Spec.Install.OLMOwnNamespace != nil {
+			targetNs = addon.Spec.Install.OLMOwnNamespace.Namespace
+		}
+	}
+
+	if len(strings.TrimSpace(targetNs)) == 0 {
+		return unschedulablePods, errors.New("failed to get addon's namespace")
+	}
+
+	if err := r.Client.List(
+		ctx,
+		addonPods,
+		client.InNamespace(targetNs),
+	); err != nil {
+		return unschedulablePods, fmt.Errorf("failed listing addon pods: %w", err)
+	}
+
+	for _, pod := range addonPods.Items {
+		for _, podCond := range pod.Status.Conditions {
+			if podCond.Type == corev1.PodScheduled &&
+				podCond.Reason == corev1.PodReasonUnschedulable &&
+				podCond.Status == corev1.ConditionFalse {
+				unschedulablePods.Items = append(unschedulablePods.Items, pod)
+			}
+		}
+	}
+	return unschedulablePods, nil
+
+}
+
+// Gathers addon data for metric collection
+func (r *AddonReconciler) recordAddonMetrics(
+	ctx context.Context,
+	addon *addonsv1alpha1.Addon) (err error) {
+
+	if r.Recorder == nil {
+		return
+	}
+
+	unschedPods := &corev1.PodList{}
+	if availableCond := meta.FindStatusCondition(
+		addon.Status.Conditions,
+		addonsv1alpha1.Available,
+	); availableCond != nil && availableCond.Status == metav1.ConditionFalse {
+		unschedPods, err = r.listUnschedulableAddonPods(ctx, addon)
+		if err != nil {
+			return err
+		}
+	}
+
+	health := addonHealth{}
+	if len(unschedPods.Items) > 0 {
+		health = UnschedulableAddonPod
+	}
+
+	r.Recorder.RecordAddonMetrics(
+		addon,
+		health,
+	)
+	return
 }

--- a/controllers/addon/addon_controller_test.go
+++ b/controllers/addon/addon_controller_test.go
@@ -137,6 +137,10 @@ func TestReconcileErrorHandling(t *testing.T) {
 			*passedAddon = *addon
 		}).Return(nil)
 
+		client.On("List", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+
+		}).Return(nil)
+
 		// invoke Reconciler
 		_, err := r.Reconcile(context.Background(), reconcile.Request{})
 

--- a/deploy/15_clusterrole.yaml
+++ b/deploy/15_clusterrole.yaml
@@ -37,6 +37,7 @@ rules:
   resources:
   - namespaces
   - secrets
+  - pods
   verbs:
   - create
   - get


### PR DESCRIPTION
### What type of PR is this?
_feature_


### What this PR does / why we need it?
This PR enables ADO to determine an unhealthy Addon due to one of its pods were unscheduled and use this cause as the reason of the addon_operator_health_info metric.

This new reason `UnschedulableAddonPod` will help an SRE determine the cause for an unhealthy addon because some of its pods failed to get scheduled by the k8s scheduler.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #MTSRE-1646_

### Special notes for your reviewer:

I've tested this locally with a kind cluster. I managed to simulate kind cluster to be in a "no available node" for scheduling state then by deploying reference addon. The metric was confirmed by querying it from ADO metrics server.

```
$ p=$(kubectl get pods -n openshift-addon-operator | grep manager | awk 'NR==1{print $1}'); kubectl exec -it $p -n openshift-addon-operator -- curl http://localhost:8443/metrics | grep health
# HELP addon_operator_addon_health_info Addon Health information
# TYPE addon_operator_addon_health_info gauge
addon_operator_addon_health_info{_id="a440b136-b2d6-406b-a884-fca2d62cd170",name="reference-addon",reason="UnschedulableAddonPod",version="1.0.0"} 0
```

Console showing reference-addon pods weren't schedulable 

![image](https://github.com/openshift/addon-operator/assets/4186494/39e56e20-5b56-492a-b662-f3bafea08b14)




