### PR TITLE
Decouple PKO integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,11 @@ test-e2e:
 	./mage test:integrationci
 .PHONY: test-e2e
 
+# Target to run PKO integration tests
+test-pko-e2e:
+	./mage test:integrationPKO
+.PHONY: test-pko-e2e
+
 ## Runs the Integration testsuite against the current $KUBECONFIG cluster. Skips operator setup and teardown.
 test-integration-short:
 	@echo "running [short] integration tests..."

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -467,20 +467,20 @@ func populateCmdCache(imageCacheDir, cmd string) error {
 		{"mkdir", "-pv", imageCacheDir + "/internal/"},
 		{"mkdir", "-pv", imageCacheDir + "/api/"},
 		{"mkdir", "-pv", imageCacheDir + "/build/bin"},
-		{"cp", "-a", "cmd/", imageCacheDir},
-		{"cp", "-a", "internal/", imageCacheDir},
-		{"cp", "-a", "api/", imageCacheDir},
-		{"cp", "-a", "build/bin/", imageCacheDir + "/build/"},
+		{"cp", "-a", "cmd", imageCacheDir},
+		{"cp", "-a", "internal", imageCacheDir},
+		{"cp", "-a", "api", imageCacheDir},
+		{"cp", "-a", "build/bin", imageCacheDir + "/build/"},
 	}
 	if cmd == "addon-operator-webhook" {
 		commands = append(commands, []string{"cp", "-a", "build/Dockerfile.webhook", imageCacheDir + "/Dockerfile"})
 	} else if cmd == "addon-operator-manager" {
 		commands = append(commands, []string{"cp", "-a", "build/Dockerfile", imageCacheDir + "/Dockerfile"})
-		commands = append(commands, []string{"cp", "-a", "boilerplate/", imageCacheDir})
-		commands = append(commands, []string{"cp", "-a", "config/", imageCacheDir})
-		commands = append(commands, []string{"cp", "-a", "controllers/", imageCacheDir})
-		commands = append(commands, []string{"cp", "-a", "hack/", imageCacheDir})
-		commands = append(commands, []string{"cp", "-a", "pkg/", imageCacheDir})
+		commands = append(commands, []string{"cp", "-a", "boilerplate", imageCacheDir})
+		commands = append(commands, []string{"cp", "-a", "config", imageCacheDir})
+		commands = append(commands, []string{"cp", "-a", "controllers", imageCacheDir})
+		commands = append(commands, []string{"cp", "-a", "hack", imageCacheDir})
+		commands = append(commands, []string{"cp", "-a", "pkg", imageCacheDir})
 		commands = append(commands, []string{"cp", "-a", "Makefile", imageCacheDir})
 		commands = append(commands, []string{"cp", "-a", "main.go", imageCacheDir})
 		commands = append(commands, []string{"cp", "-a", "options.go", imageCacheDir})


### PR DESCRIPTION
### What type of PR is this?
Creates new make/mage targets to only run PKO tests. The default target invoked from the CI now skips PKO tests.


### What this PR does / why we need it?
PKO tests are flaky hence this split.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/MTSRE-1713

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make go-test` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR
