### PR TITLE
Fix the endless reconcile of ClusterObjectTemplate

### DIFF
--- a/controllers/addon/addon_reconciler_options.go
+++ b/controllers/addon/addon_reconciler_options.go
@@ -6,6 +6,7 @@ import (
 	pkov1alpha1 "package-operator.run/apis/core/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 type AddonReconcilerOptions interface {
@@ -47,5 +48,5 @@ func (w WithPackageOperatorReconciler) ApplyToAddonReconciler(config *AddonRecon
 }
 
 func (w WithPackageOperatorReconciler) ApplyToControllerBuilder(b *builder.Builder) {
-	b.Owns(&pkov1alpha1.ClusterObjectTemplate{})
+	b.Owns(&pkov1alpha1.ClusterObjectTemplate{}, builder.WithPredicates(predicate.GenerationChangedPredicate{}))
 }


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Fix constant addon reconcile when Plug & Play feature enabled.
When an addon contains a package, the controller manager gets into an endless reconcile loop.
Root cause:

1. `PackageOperatorReconciler` updates `ClusterObjectTemplate` on every reconcile
1. Controller watches `ClusterObjectTemplate` changes.

The proposed fix adds `GenerationChangedPredicate` to skip queuing the change when `ClusterObjectTemplate` doesn't change.

### Which Jira/Github issue(s) this PR fixes?

Fixes [ROX-22814](https://issues.redhat.com//browse/ROX-22814)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make go-test` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR
