### PR TITLE
addon-operator-manager HCP pods do not have tolerations to land on non-serving nodes

### DIFF
--- a/hack/hypershift/package/hcp/addon-operator.yaml
+++ b/hack/hypershift/package/hcp/addon-operator.yaml
@@ -16,6 +16,11 @@ spec:
       labels:
         app.kubernetes.io/name: addon-operator
     spec:
+      tolerations:
+      - effect: NoSchedule
+        key: hypershift.openshift.io/request-serving-component
+        operator: Equal
+        value: "true"
       automountServiceAccountToken: false
       containers:
         - args:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_

bug
### What this PR does / why we need it?
addon-operator-manager HCP pods do not have tolerations to land on non-serving nodes

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/MTSRE-1845
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make go-test` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR
