### PR TITLE
set the delete configmap label value to true

### DIFF
--- a/controllers/addon/addon_deletion_handler_legacy.go
+++ b/controllers/addon/addon_deletion_handler_legacy.go
@@ -37,7 +37,7 @@ func (l *legacyDeletionHandler) NotifyAddon(ctx context.Context, addon *addonsv1
 		return err
 	}
 
-	if _, labelFound := currentDeleteCM.Labels[fmt.Sprintf(DeleteConfigMapLabel, addon.Name)]; labelFound {
+	if labelValue, labelFound := currentDeleteCM.Labels[fmt.Sprintf(DeleteConfigMapLabel, addon.Name)]; labelFound && labelValue == "true" {
 		return nil
 	}
 
@@ -47,7 +47,7 @@ func (l *legacyDeletionHandler) NotifyAddon(ctx context.Context, addon *addonsv1
 	if modifiedCM.Labels == nil {
 		modifiedCM.Labels = make(map[string]string)
 	}
-	modifiedCM.Labels[fmt.Sprintf(DeleteConfigMapLabel, addon.Name)] = ""
+	modifiedCM.Labels[fmt.Sprintf(DeleteConfigMapLabel, addon.Name)] = "true"
 	return l.client.Patch(ctx, modifiedCM, client.MergeFrom(currentDeleteCM))
 }
 
@@ -100,7 +100,7 @@ func (l *legacyDeletionHandler) createDeleteConfigMap(ctx context.Context, addon
 			Name:      addon.Name,
 			Namespace: addonTargetNS,
 			Labels: map[string]string{
-				fmt.Sprintf(DeleteConfigMapLabel, addon.Name): "",
+				fmt.Sprintf(DeleteConfigMapLabel, addon.Name): "true",
 			},
 		},
 	}

--- a/controllers/addon/addon_deletion_handler_legacy_test.go
+++ b/controllers/addon/addon_deletion_handler_legacy_test.go
@@ -47,7 +47,7 @@ func TestNotifyAddonLegacy(t *testing.T) {
 				require.Equal(t, addon.Name, cm.Name)
 				require.Equal(t, GetCommonInstallOptions(addon).Namespace, cm.Namespace)
 				val, found := cm.Labels[fmt.Sprintf(DeleteConfigMapLabel, addon.Name)]
-				return found && val == ""
+				return found && val == "true"
 			}),
 			[]ctrlclient.CreateOption(nil),
 		)
@@ -96,7 +96,7 @@ func TestNotifyAddonLegacy(t *testing.T) {
 				require.Equal(t, addon.Name, cm.Name)
 				require.Equal(t, GetCommonInstallOptions(addon).Namespace, cm.Namespace)
 				val, found := cm.Labels[fmt.Sprintf(DeleteConfigMapLabel, addon.Name)]
-				return found && val == ""
+				return found && val == "true"
 			}),
 			mock.Anything,
 			[]ctrlclient.PatchOption(nil),
@@ -117,7 +117,7 @@ func TestNotifyAddonLegacy(t *testing.T) {
 				Name:      addon.Name,
 				Namespace: GetCommonInstallOptions(addon).Namespace,
 				Labels: map[string]string{
-					fmt.Sprintf(DeleteConfigMapLabel, addon.Name): "",
+					fmt.Sprintf(DeleteConfigMapLabel, addon.Name): "true",
 				},
 			},
 		}

--- a/integration/addon_test.go
+++ b/integration/addon_test.go
@@ -675,7 +675,7 @@ func (s *integrationTestSuite) TestAddonDeletionFlow() {
 
 		val, found := cm.Labels[fmt.Sprintf("api.openshift.com/addon-%v-delete", addon.Name)]
 		s.Require().True(found)
-		s.Require().Equal("", val)
+		s.Require().Equal("true", val)
 
 		// Assert that the addon instance's spec.markedForDeletion is set to true.
 		instance := &addonsv1alpha1.AddonInstance{}
@@ -770,7 +770,7 @@ func (s *integrationTestSuite) TestAddonDeletionFlow() {
 
 		val, found := cm.Labels[fmt.Sprintf("api.openshift.com/addon-%v-delete", addon.Name)]
 		s.Require().True(found)
-		s.Require().Equal("", val)
+		s.Require().Equal("true", val)
 
 		err = integration.Client.Get(ctx, client.ObjectKeyFromObject(addon), addon)
 		s.Require().NoError(err)


### PR DESCRIPTION
### What type of PR is this?
The addons in the cluster expect the delete config map to a have a DeleteConfigMapLabel whose value is "true", currently we set the value to an empty string. 

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make go-test` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR
