### PR TITLE
allows to be scheduled to non-request-serving nodes

### DIFF
--- a/hack/hypershift/package/hcp/addon-operator.yaml
+++ b/hack/hypershift/package/hcp/addon-operator.yaml
@@ -16,11 +16,31 @@ spec:
       labels:
         app.kubernetes.io/name: addon-operator
     spec:
-      tolerations:
-      - effect: NoSchedule
-        key: hypershift.openshift.io/request-serving-component
-        operator: Equal
-        value: "true"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - '{{.package.metadata.namespace}}'
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: '{{.package.metadata.namespace}}'
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       automountServiceAccountToken: false
       containers:
         - args:
@@ -66,6 +86,15 @@ spec:
             capabilities:
               drop:
                 - ALL
+      tolerations:
+        - effect: NoSchedule
+          key: hypershift.openshift.io/control-plane
+          operator: Equal
+          value: "true"
+        - effect: NoSchedule
+          key: hypershift.openshift.io/cluster
+          operator: Equal
+          value: '{{.package.metadata.namespace}}'
       volumes:
         - name: kubeconfig
           secret:


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?

Allows the addon-operator pod(s) to be deployed to non-request-serving nodes.

### Which Jira/Github issue(s) this PR fixes?

_Fixes MTSRE-1845_

### Special notes for your reviewer:

I'm not exactly sure how to validate that the package is built correctly or that this deploys correctly on a cluster without deploying this, if something is wrong please feel free to take the relevant bits and adjust them as necessary and close this PR. Hopefully this at least illustrates the correct intention.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Ran `make go-test` command locally to run all the unit tests and mock tests locally.
- [x] Included documentation changes with PR - N/A
