### PR TITLE
Allows the addon-operator pod(s) to be deployed to non-request-serving nodes.

### DIFF
--- a/hack/hypershift/package/.test-fixtures/namespace-scope/hcp/addon-operator.yaml
+++ b/hack/hypershift/package/.test-fixtures/namespace-scope/hcp/addon-operator.yaml
@@ -16,11 +16,31 @@ spec:
       labels:
         app.kubernetes.io/name: addon-operator
     spec:
-      tolerations:
-      - effect: NoSchedule
-        key: hypershift.openshift.io/request-serving-component
-        operator: Equal
-        value: "true"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - 'ocm-staging-2bjb6klkupkpg4ovp0srqcteotev0773-ves-hcp'
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: 'ocm-staging-2bjb6klkupkpg4ovp0srqcteotev0773-ves-hcp'
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       automountServiceAccountToken: false
       containers:
         - args:
@@ -66,6 +86,15 @@ spec:
             capabilities:
               drop:
                 - ALL
+      tolerations:
+        - effect: NoSchedule
+          key: hypershift.openshift.io/control-plane
+          operator: Equal
+          value: "true"
+        - effect: NoSchedule
+          key: hypershift.openshift.io/cluster
+          operator: Equal
+          value: 'ocm-staging-2bjb6klkupkpg4ovp0srqcteotev0773-ves-hcp'            
       volumes:
         - name: kubeconfig
           secret:

--- a/hack/hypershift/package/hcp/addon-operator.yaml.gotmpl
+++ b/hack/hypershift/package/hcp/addon-operator.yaml.gotmpl
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: addon-operator-manager
+  labels:
+    app.kubernetes.io/name: addon-operator
+  annotations:
+    package-operator.run/phase: hosted-control-plane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: addon-operator
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: addon-operator
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/control-plane
+                operator: In
+                values:
+                - "true"
+            weight: 50
+          - preference:
+              matchExpressions:
+              - key: hypershift.openshift.io/cluster
+                operator: In
+                values:
+                - '{{.package.metadata.namespace}}'
+            weight: 100
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: '{{.package.metadata.namespace}}'
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      automountServiceAccountToken: false
+      containers:
+        - args:
+            - --enable-leader-election
+            - --metrics-addr=:8443
+            - --metrics-tls-dir=/etc/tls/manager/metrics
+          env:
+            - name: KUBECONFIG
+              value: /etc/openshift/kubeconfig/kubeconfig
+            - name: ADDON_OPERATOR_NAMESPACE
+              value: addon-operator
+          image: quay.io/app-sre/addon-operator:replaced-in-ci
+          ports:
+            - containerPort: 8443
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 100m
+              memory: 600Mi
+            requests:
+              cpu: 100m
+              memory: 300Mi
+          volumeMounts:
+            - mountPath: /etc/openshift/kubeconfig
+              name: kubeconfig
+              readOnly: true
+            - mountPath: /etc/tls/manager/metrics
+              name: manager-metrics-tls
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      tolerations:
+        - effect: NoSchedule
+          key: hypershift.openshift.io/control-plane
+          operator: Equal
+          value: "true"
+        - effect: NoSchedule
+          key: hypershift.openshift.io/cluster
+          operator: Equal
+          value: '{{.package.metadata.namespace}}'            
+      volumes:
+        - name: kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: service-network-admin-kubeconfig
+        - name: manager-metrics-tls
+          secret:
+            secretName: manager-metrics-tls

--- a/hack/hypershift/package/manifest.yaml
+++ b/hack/hypershift/package/manifest.yaml
@@ -29,3 +29,11 @@ spec:
         kind:
           group: apiextensions.k8s.io
           kind: CustomResourceDefinition
+test:
+  template:
+  - name: namespace-scope
+    context:
+      package:
+        metadata:
+          name: addon-operator-manager
+          namespace: ocm-staging-2bjb6klkupkpg4ovp0srqcteotev0773-ves-hcp    


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_
bug
Allows the addon-operator pod(s) to be deployed to non-request-serving nodes.

### What this PR does / why we need it?
Allows the addon-operator pod(s) to be deployed to non-request-serving nodes.

### Which Jira/Github issue(s) this PR fixes?
Fixes [MTSRE-1845](https://issues.redhat.com//browse/MTSRE-1845)
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make go-test` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR
