### PR TITLE
add the new file name in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,9 +290,9 @@ build-push-package:
 
 .PHONY: build-package
 build-package: validate-package
-	@chmod 777 ${PWD}/hack/hypershift/package/hcp/addon-operator.yaml
+	@chmod 777 ${PWD}/hack/hypershift/package/hcp/addon-operator.yaml.gotmpl
 	$(CONTAINER_ENGINE) run --privileged --rm -v ${PWD}:/workdir quay.io/app-sre/yq:4 -i '.spec.template.spec.containers[0].image = "$(OPERATOR_IMAGE_URI)"' \
-	hack/hypershift/package/hcp/addon-operator.yaml
+	hack/hypershift/package/hcp/addon-operator.yaml.gotmpl
 	$(CONTAINER_ENGINE) build -t $(PKG_IMG):$(PKG_IMAGETAG) -f $(join $(CURDIR),/hack/hypershift/package/addon-operator-package.Containerfile) . && \
 	$(CONTAINER_ENGINE) tag $(PKG_IMG):$(PKG_IMAGETAG) $(PKG_IMG):latest
 


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_
cleanup

### What this PR does / why we need it?
looks like https://ci.int.devshift.net/job/openshift-addon-operator-gh-build-main/551/ is failing as the Makefile still points to hack/hypershift/package/hcp/addon-operator.yaml 
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make go-test` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR
