### PR TITLE
Make Package Operator Reconciler independent of OLM Reconciler Success

### DIFF
--- a/controllers/addon/handle_installed_condition.go
+++ b/controllers/addon/handle_installed_condition.go
@@ -3,6 +3,7 @@ package addon
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -37,6 +38,14 @@ func (r *olmReconciler) handleInstalledCondition(ctx context.Context,
 	}
 
 	return resultNil, nil
+}
+
+func (r *olmReconciler) IsPKOFailed(addon *addonsv1alpha1.Addon) bool {
+	availableCondition := meta.FindStatusCondition(addon.Status.Conditions, addonsv1alpha1.Available)
+	if availableCondition != nil && strings.Contains(availableCondition.Message, "PackageOperator") {
+		return true
+	}
+	return false
 }
 
 func (r *olmReconciler) handleMissingCSV(ctx context.Context, addon *addonsv1alpha1.Addon) (requeueResult, error) {

--- a/controllers/addon/package_operator_reconciler.go
+++ b/controllers/addon/package_operator_reconciler.go
@@ -77,11 +77,12 @@ func (r *PackageOperatorReconciler) Reconcile(ctx context.Context, addon *addons
 		}
 		return ctrl.Result{}, err
 	}
-
 	return r.reconcileClusterObjectTemplate(ctx, addon)
 }
 
 func (r *PackageOperatorReconciler) reconcileClusterObjectTemplate(ctx context.Context, addon *addonsv1alpha1.Addon) (ctrl.Result, error) {
+	log := controllers.LoggerFromContext(ctx)
+	log.Info("Start reconciling PKO for addon: " + addon.Name)
 	addonDestNamespace := extractDestinationNamespace(addon)
 	reconErr := metrics.NewReconcileError("addon", r.recorder, true)
 
@@ -213,7 +214,7 @@ func (r *PackageOperatorReconciler) reconcileClusterObjectTemplate(ctx context.C
 	}
 
 	r.updateAddonStatus(addon, existingClusterObjectTemplate)
-
+	log.Info("Finish reconciling PKO for addon: " + addon.Name)
 	return ctrl.Result{}, nil
 }
 
@@ -223,6 +224,8 @@ func (r *PackageOperatorReconciler) updateAddonStatus(addon *addonsv1alpha1.Addo
 		availableCondition.ObservedGeneration != clusterObjectTemplate.GetGeneration() ||
 		availableCondition.Status != metav1.ConditionTrue {
 		reportUnreadyClusterObjectTemplate(addon)
+	} else if availableCondition != nil && availableCondition.Status == metav1.ConditionTrue {
+		reportReadinessStatus(addon)
 	}
 }
 

--- a/controllers/addon/phase_observe_operatorresource.go
+++ b/controllers/addon/phase_observe_operatorresource.go
@@ -110,7 +110,9 @@ func (r *olmReconciler) observeOperatorResource(
 
 	// If CSV is present and is in succeeded phase we report
 	// the addon as available.
-	reportReadinessStatus(addon)
+	if !r.IsPKOFailed(addon) {
+		reportReadinessStatus(addon)
+	}
 	return resultNil, nil
 }
 

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -212,7 +212,7 @@ func WaitForObject(
 	object client.Object, reason string,
 	checkFn func(obj client.Object) (done bool, err error),
 ) error {
-	return WaitForObjectWithInterval(ctx, t, time.Second, timeout, object, reason, checkFn)
+	return WaitForObjectWithInterval(ctx, t, 15*time.Second, timeout, object, reason, checkFn)
 }
 
 func WaitForObjectWithInterval(


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_
feature

### What this PR does / why we need it?
Make Package Operator Reconciler independent of OLM Reconciler Success

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/MTSRE-1408

### Special notes for your reviewer:
I did the simple fix without touching the deep code base to avoid making things complicated and out of control
So the basic idea here is to make the OLM and PKO run in parallel and all the feature toggle and their owned reconciling functions remain the same for the stable version 
There is a potential issue for the OLM to override the final status for the Addon CR with PKO when they run concurrently, add ed another simple method to avoid that happening
Although it is a small code base change, it is a big functional change for Addon, and the testing is still ongoing

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make go-test` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR
