### PR TITLE
FIX:Bumping ubi base image to resolve libxml2 CVEs

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN make go-build
 
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1216
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741795396
 
 ENV USER_UID=1001 \
     USER_NAME=addon-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1216
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741795396
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/build/Dockerfile.webhook
+++ b/build/Dockerfile.webhook
@@ -10,7 +10,7 @@ COPY . .
 RUN GOOS=linux CGO_ENABLED=1 GOARCH=amd64 GOFLAGS="" go build -o build/_output/bin/addon-operator-webhook ./cmd/addon-operator-webhook
 
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1216
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741795396
 
 ENV USER_UID=1001 \
     USER_NAME=addon-operator


### PR DESCRIPTION
### What type of PR is this?
FIX

### What this PR does / why we need it?
This PR bumps the ubi base image to

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/MTSRE-2043

_Fixes #_
https://access.redhat.com/security/cve/CVE-2025-24928

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make go-test` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR
