### PR TITLE
fix: move webhook into main image and override entrypoint in deployment  manifest

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,6 +8,7 @@ RUN go mod download
 COPY . .
 
 RUN make go-build
+RUN GOOS=linux CGO_ENABLED=1 GOARCH=amd64 GOFLAGS="" go build -o build/_output/bin/addon-operator-webhook ./cmd/addon-operator-webhook
 
 ###
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773939694

--- a/build/Dockerfile.webhook
+++ b/build/Dockerfile.webhook
@@ -1,3 +1,5 @@
+# Unused - the webhook binary is now part of the main image.
+
 FROM quay.io/redhat-services-prod/openshift/boilerplate:image-v8.3.1 AS builder
 
 WORKDIR /workdir

--- a/deploy_pko/Deployment-addon-operator-webhooks.yaml.gotmpl
+++ b/deploy_pko/Deployment-addon-operator-webhooks.yaml.gotmpl
@@ -52,6 +52,8 @@ spec:
       containers:
       - name: webhook
         image: '{{ .config.image }}'
+        command:
+        - /usr/local/bin/addon-operator-webhook
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/deploy_pko/Deployment-addon-operator-webhooks.yaml.gotmpl
+++ b/deploy_pko/Deployment-addon-operator-webhooks.yaml.gotmpl
@@ -49,13 +49,22 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      volumes:
+      - name: serving-cert
+        secret:
+          secretName: addon-operator-webhook-tls
       containers:
       - name: webhook
         image: '{{ .config.image }}'
         command:
         - /usr/local/bin/addon-operator-webhook
+        args:
+        - --cert-dir=/mnt/serving-cert
         ports:
         - containerPort: 8080
+        volumeMounts:
+        - name: serving-cert
+          mountPath: /mnt/serving-cert
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy_pko/Service-addon-operator-webhook.yaml
+++ b/deploy_pko/Service-addon-operator-webhook.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: addon-operator-webhook
+  namespace: openshift-addon-operator
+  labels:
+    app.kubernetes.io/name: addon-operator
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: addon-operator-webhook-tls
+    package-operator.run/phase: deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+  - name: https
+    port: 443
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/name: addon-operator

--- a/deploy_pko/ValidatingWebhookConfiguration-addons.yaml
+++ b/deploy_pko/ValidatingWebhookConfiguration-addons.yaml
@@ -1,0 +1,32 @@
+# This manifest is only for testing and should be used with `00-tls-secret.yaml`
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: addon-validating-webhook-configuration
+  annotations:
+    package-operator.run/phase: validatingwebhook
+    package-operator.run/collision-protection: IfNoController
+    service.beta.openshift.io/inject-cabundle: "true"
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: openshift-addon-operator
+      path: /validate-addon
+  failurePolicy: Fail
+  name: vaddons.managed.openshift.io
+  rules:
+  - apiGroups:
+    - addons.managed.openshift.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - addons
+  sideEffects: None
+
+# service.beta.openshift.io/serving-cert-secret-name=<secret_name>

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -9,6 +9,7 @@ spec:
   - Cluster
   phases:
   - name: crds
+  - name: validatingwebhook
   - name: namespace
   - name: rbac
   - name: deploy


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_
bugfix

### What this PR does / why we need it?

ensures that the webhook deployment runs the webhook binary

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://redhat.atlassian.net/browse/SLSRE-660

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make go-test` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened webhook build configuration to ensure proper binary compilation and container image inclusion with standardized settings.
  * Enhanced webhook container deployment with explicit startup command specification for improved service initialization and operational consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->