### PR TITLE
fix: add back ADO CR to PKO template

### DIFF
--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -16,6 +16,12 @@ parameters:
   - name: REPO_NAME
     value: addon-operator
     required: true
+  - name: OCM_BASE_URL
+    value: http://api-mock.api-mock.svc.cluster.local
+    required: true
+  - name: FEATURE_FLAGS
+    value: ""
+    required: true
 metadata:
   name: selectorsyncset-template
 objects:
@@ -43,3 +49,14 @@ objects:
             image: ${PKO_IMAGE}:${IMAGE_TAG}
             config:
               image: ${OPERATOR_IMAGE}:${IMAGE_TAG}
+        - apiVersion: addons.managed.openshift.io/v1alpha1
+          kind: AddonOperator
+          metadata:
+            name: addon-operator
+          spec:
+            featureFlags: ${FEATURE_FLAGS}
+            ocm:
+              endpoint: ${OCM_BASE_URL}
+              secret:
+                name: pull-secret
+                namespace: openshift-config


### PR DESCRIPTION
### What type of PR is this?
_fix_


### What this PR does / why we need it?

Adds back configured ADO CR to PKO template

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make go-test` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cluster configuration by introducing AddonOperator resource with OCM endpoint and feature flag parameters for improved add-on management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->