### PR TITLE
fix: prevent servicemonitor from scraping webhooks

### DIFF
--- a/deploy_pko/Service-addon-operator-webhook.yaml
+++ b/deploy_pko/Service-addon-operator-webhook.yaml
@@ -3,8 +3,6 @@ kind: Service
 metadata:
   name: addon-operator-webhook
   namespace: openshift-addon-operator
-  labels:
-    app.kubernetes.io/name: addon-operator
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: addon-operator-webhook-tls
     package-operator.run/phase: deploy


### PR DESCRIPTION
### What type of PR is this?
_fix_


### What this PR does / why we need it?

Prevents ServiceMonitor from attempting to scrape wehbook service

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make go-test` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Service configuration for addon operator webhook resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->