### PR TITLE
SREP-4577: Fix webhook drain deadlock with preStop hook and failurePolicy: Ignore

### DIFF
--- a/bundle/manifests/addon-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/addon-operator.clusterserviceversion.yaml
@@ -377,7 +377,7 @@ spec:
     - v1
     containerPort: 443
     deploymentName: addon-operator-webhooks
-    failurePolicy: Fail
+    failurePolicy: Ignore
     generateName: vaddons.managed.openshift.io
     rules:
     - apiGroups:

--- a/config/templates/csv-template.yaml
+++ b/config/templates/csv-template.yaml
@@ -53,7 +53,7 @@ spec:
         - v1
       containerPort: 443
       deploymentName: addon-operator-webhooks
-      failurePolicy: Fail
+      failurePolicy: Ignore
       generateName: vaddons.managed.openshift.io
       rules:
         - apiGroups:

--- a/config/templates/csv-template.yaml
+++ b/config/templates/csv-template.yaml
@@ -53,6 +53,8 @@ spec:
         - v1
       containerPort: 443
       deploymentName: addon-operator-webhooks
+      # Ignore so webhook unavailability during node drains does not block MCO.
+      # Compensating controls: 2 replicas with pod anti-affinity, preStop hook.
       failurePolicy: Ignore
       generateName: vaddons.managed.openshift.io
       rules:

--- a/deploy-extras/development/webhook/validatingwebhookconfig.yaml
+++ b/deploy-extras/development/webhook/validatingwebhookconfig.yaml
@@ -14,6 +14,8 @@ webhooks:
       name: webhook-service
       namespace: openshift-addon-operator
       path: /validate-addon
+  # Ignore so webhook unavailability during node drains does not block MCO.
+  # Compensating controls: 2 replicas with pod anti-affinity, preStop hook.
   failurePolicy: Ignore
   name: vaddons.managed.openshift.io
   rules:

--- a/deploy-extras/development/webhook/validatingwebhookconfig.yaml
+++ b/deploy-extras/development/webhook/validatingwebhookconfig.yaml
@@ -14,7 +14,7 @@ webhooks:
       name: webhook-service
       namespace: openshift-addon-operator
       path: /validate-addon
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vaddons.managed.openshift.io
   rules:
   - apiGroups:

--- a/deploy/70_webhook-deployment.yaml
+++ b/deploy/70_webhook-deployment.yaml
@@ -49,6 +49,10 @@ spec:
       containers:
       - name: webhook
         image: quay.io/openshift/addon-operator-webhook:latest
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "5"]
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/deploy_pko/ValidatingWebhookConfiguration-addons.yaml
+++ b/deploy_pko/ValidatingWebhookConfiguration-addons.yaml
@@ -15,6 +15,8 @@ webhooks:
       name: addon-operator-webhook
       namespace: openshift-addon-operator
       path: /validate-addon
+  # Ignore so webhook unavailability during node drains does not block MCO.
+  # Compensating controls: 2 replicas with pod anti-affinity, preStop hook.
   failurePolicy: Ignore
   name: vaddons.managed.openshift.io
   rules:

--- a/deploy_pko/ValidatingWebhookConfiguration-addons.yaml
+++ b/deploy_pko/ValidatingWebhookConfiguration-addons.yaml
@@ -15,7 +15,7 @@ webhooks:
       name: addon-operator-webhook
       namespace: openshift-addon-operator
       path: /validate-addon
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vaddons.managed.openshift.io
   rules:
   - apiGroups:

--- a/hack/webhookdefinition.yaml
+++ b/hack/webhookdefinition.yaml
@@ -2,6 +2,8 @@
         - v1
       containerPort: 443
       deploymentName: addon-operator-webhooks
+      # Ignore so webhook unavailability during node drains does not block MCO.
+      # Compensating controls: 2 replicas with pod anti-affinity, preStop hook.
       failurePolicy: Ignore
       generateName: vaddons.managed.openshift.io
       rules:

--- a/hack/webhookdefinition.yaml
+++ b/hack/webhookdefinition.yaml
@@ -2,7 +2,7 @@
         - v1
       containerPort: 443
       deploymentName: addon-operator-webhooks
-      failurePolicy: Fail
+      failurePolicy: Ignore
       generateName: vaddons.managed.openshift.io
       rules:
         - apiGroups:


### PR DESCRIPTION
## Summary

- Adds a 5-second preStop sleep to the webhook deployment to allow endpoint deregistration before shutdown
- Changes failurePolicy from Fail to Ignore on the ValidatingWebhookConfiguration to prevent API server hangs during drains

## Problem

The addon-operator-webhooks pod gets stuck in Terminating during MCO node drains, blocking the drain for 1+ hour. This causes cascading alerts (ControlPlaneNodeUnschedulableSRE, ClusterMonitoringErrorBudgetBurnSRE) and requires SRE force-deletion to resolve.

Observed twice in 2 hours on the same cluster (rosaprod.gxp9.p1, af-south-1), on two different infra nodes.

## Root Cause

Race condition during eviction: the pod stops serving requests but remains registered as a webhook backend. With failurePolicy: Fail, API calls to the dying pod hang rather than failing open. This prevents clean termination and blocks the MCO drain indefinitely.

## Fix

Two changes that provide defense-in-depth:

1. **preStop sleep (5s)**: Gives the endpoints controller time to remove the pod from the Service before it stops serving. Standard Kubernetes pattern for webhook pods.

2. **failurePolicy: Ignore**: If the webhook pod is unavailable during drain, the API server skips validation instead of hanging. The second replica continues serving most requests, so the validation gap is minimal (a few seconds during node drain).

Jira: https://redhat.atlassian.net/browse/SREP-4577

## Test plan

- [ ] Deploy to a test cluster with the webhook running on infra nodes
- [ ] Cordon and drain an infra node hosting a webhook pod
- [ ] Verify the pod terminates cleanly without blocking the drain
- [ ] Verify webhook availability during the drain (second replica serves requests)
- [ ] Verify addon CRD validation still works under normal conditions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Webhook admission behavior changed to be tolerant of webhook failures: when the admission webhook is unavailable or errors, API requests are allowed to proceed instead of being blocked.
  * Webhook service now delays shutdown briefly (small pre-stop pause) to reduce connection interruptions and improve stability during updates or rolling restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->