### PR TITLE
disable scc.podSecurityLabelSync on the addon-operator namespace to prevent broad SCCs and CRBs from downgrading the pod-security labels in this namespace

### DIFF
--- a/deploy_pko/Namespace-openshift-addon-operator.yaml
+++ b/deploy_pko/Namespace-openshift-addon-operator.yaml
@@ -12,4 +12,4 @@ metadata:
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest
-    security.openshift.io/scc.podSecurityLabelSync: "true"
+    security.openshift.io/scc.podSecurityLabelSync: "false" # to remediate https://redhat.atlassian.net/browse/SLSRE-669


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_


### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make go-test` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated namespace configuration to disable automatic pod security label synchronization. This infrastructure change modifies how security policies are applied to containers and affects the overall security compliance state of the namespace. Associated documentation updates and remediation references have been included to support operations and compliance requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->