### PR TITLE
chore(pre-commit): exclude .claude/settings.json from pre-commit validation because it is managed by boilerplate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,8 @@ exclude: |
   (?x)(
     (^vendor/)|
     (.deepcopy.go$)|
-    (mage_output_file.go$)
+    (mage_output_file.go$)|
+    (.claude/settings.json$)
   )
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_


### What this PR does / why we need it?

Excludes `.claude/settings.json` from pre-commit validation so that https://github.com/openshift/addon-operator/pull/750 can be merged.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make go-test` command locally to run all the unit tests and mock tests locally.
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tool configuration to exclude additional files from pre-commit checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->