### PR TITLE
Remove srep-infra-cicd from OWNERS files [SDCICD-1761]

### DIFF
--- a/.tekton/OWNERS
+++ b/.tekton/OWNERS
@@ -1,4 +1,0 @@
-reviewers:
-- srep-infra-cicd
-approvers:
-- srep-infra-cicd


### PR DESCRIPTION
The srep-infra-cicd migration is now complete. This PR removes the team as owners from this repository.

Related: Similar cleanup across OpenShift managed services repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review and approval configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->