### PR TITLE
ROSA-745: boilerplate-update and enable MintMaker gomod

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>openshift/boilerplate//.github/renovate.json"
+  ],
+  "enabledManagers": [
+    "tekton",
+    "gomod"
   ]
 }

--- a/integration/fixtures_test.go
+++ b/integration/fixtures_test.go
@@ -27,7 +27,7 @@ var (
 	// Latest
 	referenceAddonCatalogSourceImageWorkingLatest = "quay.io/osd-addons/reference-addon-index@sha256:2403bcb6d6f61ba3cd9d3a4653edeb852026a1edc0c49f416d3df5008dad37e8"
 
-	// The latest bundle in this index image deploys a version of our referene-addon where InstallPlan and CSV never succeed
+	// The latest bundle in this index image deploys a version of our referee-addon where InstallPlan and CSV never succeed
 	// because the deployed operator pod is deliberately broken through invalid readiness and liveness probes.
 	// Version: v0.1.3
 	referenceAddonCatalogSourceImageBroken = "quay.io/osd-addons/reference-addon-index@sha256:9e6306e310d585610d564412780d58ec54cb24a67d7cdabfc067ab733295010a"


### PR DESCRIPTION
## Summary

- `make boilerplate-update` (includes boilerplate #748 dependabot template)
- `.github/renovate.json` — `enabledManagers: [tekton, gomod]` for MintMaker gomod PRs

## Test plan

- [ ] CI green

Jira: [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository automation settings to explicitly include additional package manager support.
* **Documentation**
  * Corrected a spelling mistake in an internal comment for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->